### PR TITLE
Fix get_urgency_color bug.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 = GENI Portal Release Notes =
 
 == 2.34 ==
-
+ * Fix get_urgency_color bug, now properly computes time interval for color (#1387) 
 
 == 2.33 ==
  * Add dropdown to get logs for a given time period on homepage, slice page,

--- a/lib/php/tool-slices.php
+++ b/lib/php/tool-slices.php
@@ -183,7 +183,7 @@ function get_urgency_color($exp_date){
     return "red; text-decoration: underline;";
   } 
   $interval = date_diff($exp_datetime, $now);
-  $num_hours = $interval->d * 24 + $interval->h;
+  $num_hours = $interval->days * 24 + $interval->h;
   if ($num_hours < 24) { 
     return "red";
   } else if ($num_hours < 48) {


### PR DESCRIPTION
get_urgency_color was ignoring the month and year difference when
computing the time interval between two dates, resulting in red
being displayed for intervals like 06/06 and 12/06. Updated code
to actually compute the difference between the two dates using
interval->days instead of interval->d. (fixes #1387 )