### PR TITLE
Paint ready resources in green in safari.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@
  * Add `isManifest` to Jacks app (#1419).
  * Fix problem with jacks-app talking to racks rather than ExoSM
    for ExoSM-allocated resources (#1401).
+ * Make ready resources green in Safari (#1436)
 
 == 2.33 ==
  * Add dropdown to get logs for a given time period on homepage, slice page,

--- a/portal/www/portal/jacks-app.js
+++ b/portal/www/portal/jacks-app.js
@@ -1034,7 +1034,7 @@ JacksApp.prototype.hasLoginInfo = function(am_id)
 	    if(has_login_info) return false;
 	    var client_host_keys = Object.keys(that.loginInfo[username]);
 	    $.each(client_host_keys, function(i, client_host_key) {
-		    if (client_host_key.includes(agg_urn)) {
+            if (client_host_key.indexOf(agg_urn) > -1) {
 			has_login_info = true;
 			return false;
 		    }


### PR DESCRIPTION
Safari doesn't implement the string prototype method 'includes' so
revert to indexOf to make it work across browsers. Fixes #1436.