### PR TITLE
Fix Jacks App login info polling.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@
  * Fix problem with jacks-app talking to racks rather than ExoSM
    for ExoSM-allocated resources (#1401).
  * Make ready resources green in Safari (#1436)
+ * Limit jacks app login polling to max time of 5 minutes (#1439)
 
 == 2.33 ==
  * Add dropdown to get logs for a given time period on homepage, slice page,


### PR DESCRIPTION
Set a max time for polling instead of passing around NaN. Check the
max poll time before requesting a manifest from the embedding
page. Fixes #1439.