### PR TITLE
Fix redirects when project is successfully created.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 = GENI Portal Release Notes =
 
 == 2.34 ==
+ * Fix redirects when project is successfully created. (#1434)
  * Fix omni_invocation parsing to mark an error/failed if the aggregate
    returns "Error" in return text but not in code (#1134, #1406).
  * Clear RSpec selector (paste, file, url, menu) when Jacks delete all or

--- a/portal/www/portal/do-edit-project.php
+++ b/portal/www/portal/do-edit-project.php
@@ -144,7 +144,7 @@ if (! isset($name) or is_null($name) or $name == '') {
 } else {
   $_SESSION['lastmessage'] = "Edited project $name: $result";
 }
-show_header('GENI Portal: Projects', $TAB_PROJECTS);
+// show_header('GENI Portal: Projects', $TAB_PROJECTS);
 relative_redirect('project.php?project_id='.$project_id . "&result=" . $result);
 
 include("footer.php");


### PR DESCRIPTION
show_header() was being unnecessarily called before redirect on successful creation of a new project. On the new dashboard, where the header is long enough that content gets printed to the php output before the redirect, this would cause a php error. Fixes #1434.