### PR TITLE
Fix jacks-app looping

### DIFF
--- a/portal/www/portal/jacks-app.js
+++ b/portal/www/portal/jacks-app.js
@@ -926,7 +926,7 @@ JacksApp.prototype.onEpStatus = function(event) {
     var that = this;
     // We just go through all entries in currentStatusByAM
     $.each(this.currentStatusByAm, function (am_id, statusAndmaxTime) {
-       if (am_id != event.am_id) return false; // Exit this inner function call
+       if (am_id != event.am_id) return; // Exit this inner function call
        that.handleNewStatus(am_id, statusAndmaxTime[0], statusAndmaxTime[1],
 			    true);
 	});


### PR DESCRIPTION
Jacks-app was prematurely terminating the loop in status detection
which caused some resources to not be marked as ready. Similarly,
delete did not loop long enough to refresh the manifest and note that
the resources were gone.

Stop returning false from the `$.each()` callback function to loop over all aggregates. Returning false exits the loop while just returning continues the loop.