### PR TITLE
Restore manage resources functionality

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 
 == 2.35 ==
  * Remove account and identity (and associated) tables, scripts and clients (#299)
+ * Restore 'Manage Resources' functionality (#1448)
 
 == 2.34 ==
  * Fix redirects when project is successfully created. (#1434)

--- a/portal/www/portal/slice.php
+++ b/portal/www/portal/slice.php
@@ -538,7 +538,7 @@ print "<h2></h2>\n";
 
 ?>
 
-
+<a id='manage'></a>
 <div id='tablist'>
   <ul class='tabs'>
     <li><a href='#jacks-app'>Graphical View</a></li>


### PR DESCRIPTION
Make the manage resources button on the slice page link once again to
the manage resources section of the page. The target seems to have
been lost. Fixes #1448.