### PR TITLE
Fix wimax-enable redirect loop

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
  * Add create image function for PG/IG racks within jacks-app (#1389).
  * Remove account and identity (and associated) tables, scripts and clients (#299)
  * Restore 'Manage Resources' functionality (#1448)
+ * Fix infinite redirect on wimax-enable with no projects (#1464)
 
 == 2.34 ==
  * Fix redirects when project is successfully created. (#1434)

--- a/portal/www/portal/wimax-enable.php
+++ b/portal/www/portal/wimax-enable.php
@@ -905,7 +905,7 @@ if (isset($user->ma_member->enable_wimax)) {
 } else { // user not enabled
   if ($num_projects == 0) {
     $_SESSION['lasterror'] = 'You are not a member of any projects.';
-    relative_redirect('wimax-enable.php');
+    relative_redirect('home.php');
   }
 }
 


### PR DESCRIPTION
If a user is not a member of any projects, redirect to home page
instead of back to wimax-enable. The redirect onto itself caused a
redirect loop.

Fixes #1464.