### PR TITLE
Don't store all profile changes as lead requests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@
  * Add create image function for PG/IG racks within jacks-app (#1389).
  * Remove account and identity (and associated) tables, scripts and clients (#299)
  * Restore 'Manage Resources' functionality (#1448)
+ * Avoid always storing profile changes as lead requests. (#1463)
+ * Avoid listing all profile edits as having changed the telephone number. (#1339)
 
 == 2.34 ==
  * Fix redirects when project is successfully created. (#1434)


### PR DESCRIPTION
issue #1339: Use `==`, not `===` to see if profile value changed, to avoid emailing that the phone # changed when it did not. 

issue #1463: re-organize code to only store profile change as a lead request if this is indeed a lead request and there isn't one already. At the same time, re-order code so admins get email on a duplicate lead request, and get notified of the profile changes.