### PR TITLE
Fix undefine variable in log_db_error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
  * Add create image function for PG/IG racks within jacks-app (#1389).
  * Remove account and identity (and associated) tables, scripts and clients (#299)
  * Restore 'Manage Resources' functionality (#1448)
+ * Fix undefined variable in log_db_error (#1467)
 
 == 2.34 ==
  * Fix redirects when project is successfully created. (#1434)

--- a/lib/php/db_utils.php
+++ b/lib/php/db_utils.php
@@ -100,7 +100,7 @@ function db_execute_statement($stmt, $msg = "", $rollback_on_error = false)
 function log_db_error($error_result, $query, $msg)
 {
   if ($msg) {
-    $log_msg .= "DB ERROR $msg: \"";
+    $log_msg = "DB ERROR $msg: \"";
   } else {
     $log_msg = "DB ERROR: \"";
   }


### PR DESCRIPTION
Set the variable instead of appending to a non-existent
variable. Fixes #1467.