### PR TITLE
Handle text overflow on project and slice cards on dashboard.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 == 3.1 ==
  * Add link to "Other Tools" wiki page listing Omni, VTS, geni-lib, etc. (#1457)
  * Fix erroneous warning when renewing slices on the dashboard (#1481)
+ * Handle text overflow for project names and lead names on dashboard (#1484)
 
 == 3.0 ==
  * Add create image function for PG/IG racks within jacks-app (#1389).

--- a/portal/www/common/css/dashboard.css
+++ b/portal/www/common/css/dashboard.css
@@ -85,12 +85,23 @@ td .material-icons {
   cursor: pointer;
 }
 
-.slicename, .projectname, .leadname {
+.slicename, .projectname, .leadname, .smallleadname {
   display: block;
   width: calc(300px - 20px);
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+}
+
+.smallleadname {
+  max-width: 170px;
+  float: left;
+}
+
+.requeststring {
+  display: block;
+  width: 110px;
+  float: left;
 }
 
 .slicetopbar .slicename, .projectname {

--- a/portal/www/common/css/dashboard.css
+++ b/portal/www/common/css/dashboard.css
@@ -51,7 +51,7 @@ td .material-icons {
 }
 
 .slicebox {
-  width: 290px;
+  width: 300px;
   padding: 0px;
   margin: 15px 10px 15px 20px;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
@@ -71,6 +71,7 @@ td .material-icons {
 
 #content .slicebox td {
   font-size: 14px;
+  padding: 5px 10px;
 }
 
 #content .slicebox .slicetopbar {
@@ -84,15 +85,19 @@ td .material-icons {
   cursor: pointer;
 }
 
-.slicename, .projectname {
+.slicename, .projectname, .leadname {
   display: block;
-  color: #FFFFFF !important;
-  text-decoration: none !important;
-  width: 100%;
-  max-width: 200px;
+  width: calc(300px - 20px);
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
+}
+
+.slicetopbar .slicename, .projectname {
+  display: block;
+  max-width: 200px;
+  color: #FFFFFF !important;
+  text-decoration: none !important;
 }
 
 .slicename:hover, .projectname:hover {

--- a/portal/www/common/css/newportal.css
+++ b/portal/www/common/css/newportal.css
@@ -191,8 +191,8 @@ body {
   border-radius: 3px;
   margin-left: auto;
   margin-right: auto;
-  width: 92.5%;
-  max-width: 1500px;
+  width: 95%;
+  max-width: 1400px;
   min-width: 800px;
   margin: 25px auto 35px auto;
 }

--- a/portal/www/portal/dashboard.php
+++ b/portal/www/portal/dashboard.php
@@ -445,8 +445,8 @@ if (! $user->portalIsAuthorized()) {
       }
     }
     $box .= "</ul></li></ul></td></tr>";
-    $box .= "<tr><td colspan='2'><b>Project:</b> $project_name </td></tr>";
-    $box .= "<tr><td colspan='2'><b>Owner:</b> $lead_name</td></tr>";
+    $box .= "<tr><td colspan='2'><span class='leadname'><b>Project:</b> $project_name </span></td></tr>";
+    $box .= "<tr><td colspan='2'><span class='leadname'><b>Owner:</b> $lead_name</span></td></tr>";
     $box .= "<tr style='height:40px;'><td>$slice_info</td><td style='vertical-align: middle; width:30px;'>";
     $box .= "<i class='material-icons' style='color:$slice_exp_color;'>$slice_exp_icon</i></td></tr>";
     $box .= "<tr style='height:40px;'><td style='border-bottom:none;'>$resource_info</td>";
@@ -508,7 +508,7 @@ if (! $user->portalIsAuthorized()) {
       $expiration_icon = "";
     }
     $box .= "<tr><td style='border-bottom:none'>$expiration_string</td>";
-    $box .= "<td style='vertical-align: middle; border-bottom:none; height: 35px;'>$expiration_icon</td></tr>";
+    $box .= "<td style='vertical-align: middle; border-bottom:none;'>$expiration_icon</td></tr>";
     $box .= "</table></div>";
     return $box;
   }

--- a/portal/www/portal/dashboard.php
+++ b/portal/www/portal/dashboard.php
@@ -135,6 +135,7 @@ if (! $user->portalIsAuthorized()) {
     $user_id = $user->account_id;
 
     // Make and fill dictionary of project join requests
+    // Do this for ACTIVE projects only
     $project_request_map = array();
     if (count($project_objects) > 0) {
       $reqlist = get_pending_requests_for_user($sa_url, $user, $user->account_id, 
@@ -447,9 +448,9 @@ if (! $user->portalIsAuthorized()) {
     $box .= "</ul></li></ul></td></tr>";
     $box .= "<tr><td colspan='2'><span class='leadname'><b>Project:</b> $project_name </span></td></tr>";
     $box .= "<tr><td colspan='2'><span class='leadname'><b>Owner:</b> $lead_name</span></td></tr>";
-    $box .= "<tr style='height:40px;'><td>$slice_info</td><td style='vertical-align: middle; width:30px;'>";
+    $box .= "<tr style='height:40px;'><td style='padding: 0px 10px;'>$slice_info</td><td style='vertical-align: middle; width:30px;'>";
     $box .= "<i class='material-icons' style='color:$slice_exp_color;'>$slice_exp_icon</i></td></tr>";
-    $box .= "<tr style='height:40px;'><td style='border-bottom:none;'>$resource_info</td>";
+    $box .= "<tr style='height:40px;'><td style='border-bottom:none; padding: 0px 10px;'>$resource_info</td>";
     $box .= "<td style='vertical-align: middle; border-bottom:none'>";
     $box .= "$resource_exp_icon</td></tr>";
     $box .= "</table></div>";
@@ -490,7 +491,12 @@ if (! $user->portalIsAuthorized()) {
       $box .= "<li><a href='edit-project-member.php?project_id=$project_id'>Edit membership</a></li>";
     }
     $box .= "</ul></li></ul></td></tr>";
-    $box .= "<tr><td colspan='2'><b>Lead:</b> $lead_name $handle_req_str</td></tr>";
+    if ($handle_req_str) {
+      $box .= "<tr><td colspan='2'><span class='smallleadname'><b>Lead:</b> $lead_name </span> <span class='requeststring'>$handle_req_str</span></td></tr>";
+    } else {
+      $box .= "<tr><td colspan='2'><span class='leadname'><b>Lead:</b> $lead_name </span></td></tr>";
+    }
+
     $box .= $slice_count == 0 ? "<tr><td colspan='2'><i> No slices</i></td></tr>" : "<tr><td colspan='2'>Has <b>$slice_count</b> slices</td></tr>";
     if ($expiration) {
       if (!$expired) {
@@ -507,7 +513,7 @@ if (! $user->portalIsAuthorized()) {
       $expiration_string = "<i>No expiration</i>";
       $expiration_icon = "";
     }
-    $box .= "<tr><td style='border-bottom:none'>$expiration_string</td>";
+    $box .= "<tr style='height: 40px;'><td style='border-bottom:none;'>$expiration_string</td>";
     $box .= "<td style='vertical-align: middle; border-bottom:none;'>$expiration_icon</td></tr>";
     $box .= "</table></div>";
     return $box;


### PR DESCRIPTION
Long names now get truncated with ellipses instead of making the cards taller. To accommodate long names, also widen slice/project cards and the overall body width slightly.  Fixes #1484.