### PR TITLE
Make projects.php redirect to projects tab on the dashboard.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 == 3.1 ==
  * Add link to "Other Tools" wiki page listing Omni, VTS, geni-lib, etc. (#1457)
  * Fix erroneous warning when renewing slices on the dashboard (#1481)
+ * Make projects.php redirect to projects tab on the dashbaord (#1487)
 
 == 3.0 ==
  * Add create image function for PG/IG racks within jacks-app (#1389).

--- a/portal/www/portal/projects.php
+++ b/portal/www/portal/projects.php
@@ -26,9 +26,11 @@
 // NOTE: This page is deprecated as of 8/2015 with the release of Portal 3.0
 // This page now simply redirects to the Projects tab of the new dashboard. 
 //--------------------------------------------------------------------------
-require_once("header.php");
+
+require_once("util.php");
 relative_redirect("dashboard.php#projects");
 
+require_once("header.php");
 require_once("user.php");
 include("services.php");
 

--- a/portal/www/portal/projects.php
+++ b/portal/www/portal/projects.php
@@ -22,14 +22,22 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 
-require_once("user.php");
+//--------------------------------------------------------------------------
+// NOTE: This page is deprecated as of 8/2015 with the release of Portal 3.0
+// This page now simply redirects to the Projects tab of the new dashboard. 
+//--------------------------------------------------------------------------
 require_once("header.php");
+relative_redirect("dashboard.php#projects");
+
+require_once("user.php");
 include("services.php");
 
 $user = geni_loadUser();
 if (!isset($user) || is_null($user) || ! $user->isActive()) {
   relative_redirect('home.php');
 }
+
+
 show_header('GENI Portal: Projects', $TAB_PROJECTS);
 include("tool-breadcrumbs.php");
 include("tool-showmessage.php");

--- a/portal/www/portal/slices.php
+++ b/portal/www/portal/slices.php
@@ -26,10 +26,10 @@
 // NOTE: This page is deprecated as of 8/2015 with the release of Portal 3.0
 // This page now simply redirects to the Slices tab of the new dashboard. 
 //--------------------------------------------------------------------------
-require_once("header.php");
+require_once("util.php");
 relative_redirect("dashboard.php#slices");
 
-
+require_once("header.php");
 require_once("user.php");
 require_once("sr_client.php");
 require_once("sr_constants.php");

--- a/portal/www/portal/slices.php
+++ b/portal/www/portal/slices.php
@@ -22,8 +22,15 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 
-require_once("user.php");
+//--------------------------------------------------------------------------
+// NOTE: This page is deprecated as of 8/2015 with the release of Portal 3.0
+// This page now simply redirects to the Slices tab of the new dashboard. 
+//--------------------------------------------------------------------------
 require_once("header.php");
+relative_redirect("dashboard.php#slices");
+
+
+require_once("user.php");
 require_once("sr_client.php");
 require_once("sr_constants.php");
 require_once("sa_client.php");
@@ -34,7 +41,6 @@ $user = geni_loadUser();
 if (!isset($user) || is_null($user) || ! $user->isActive()) {
   relative_redirect('home.php');
 }
-relative_redirect('dashboard.php#slices');
 
 show_header('GENI Portal: Slices', $TAB_SLICES);
 include("tool-breadcrumbs.php");


### PR DESCRIPTION
Also add notes in both slices.php and projects.php that the pages are deprecated and redirect to the dashboard. Fixes #1487