### PR TITLE
Fix bug where hamburger menu would expand on every page resize.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@
  * Update welcome page to use new portal CSS styles.
  * Make projects.php redirect to projects tab on the dashbaord (#1487)
  * Add Google Analytics (via adding header) to jacks expanded views (#1488)
+ * Fix bug where hamburger menu would expand on every page resize (#1500)
 
 == 3.0 ==
  * Add create image function for PG/IG racks within jacks-app (#1389).

--- a/portal/www/portal/dashboard.js
+++ b/portal/www/portal/dashboard.js
@@ -66,7 +66,9 @@ $(document).ready(function(){
   });
 
   $(window).resize(function() {
-    $("#dashboardtools").show();
+    if ($(window).width() > 480) {
+      $("#dashboardtools").show();
+    }
   });
 
 });


### PR DESCRIPTION
Only show the menu on page resize if in desktop view. Fixes #1500.