### PR TITLE
Fix bug where login screen gets embedded in logs card on session timeout

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 = GENI Portal Release Notes =
 
 == 3.2 ==
+ * Fix bug where login screen gets embedded in logs card on session timeout (#1460)
  * Allow for sorting of slices by project name on dashboard (#1497)
  * Update slice page to use new tab/cards style (#1509)
  * Make project names on slice cards a link to that project (#1512)

--- a/portal/www/portal/dashboard.js
+++ b/portal/www/portal/dashboard.js
@@ -133,7 +133,11 @@ function update_selector(selector, newval) {
 // Retrieve all the GENI logs for the user in the past hours hours
 function get_logs(hours){
   $.get("do-get-logs.php?hours="+hours, function(data) {
-    $('#logtable').html(data);
+    if (data.split("<html").length == 1) {
+      $('#logtable').html(data);
+    } else {
+      location.reload();
+    }
   });
 }
 


### PR DESCRIPTION
Fixes #1460. If your session times out and you click to click the logs dropdown, you get redirected to the login screen.