### PR TITLE
Use UTC for database timestamps

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 = GENI Portal Release Notes =
 
 == 3.3 ==
+ * Store timestamps in UTC for last_seen, lead requests, and KM asserted attributes. (#1446)
 
 == 3.2 ==
  * Move SR certs from geni-portal to geni-ch (geni-ch #102).

--- a/kmtool/Makefile.am
+++ b/kmtool/Makefile.am
@@ -5,7 +5,8 @@ svcdatadir = $(pkgdatadir)/km
 svcwebdir = /var/www/secure
 svccssdir = /var/www/common/css
 
-nobase_dist_svcdata_DATA = db/postgresql/schema.sql
+nobase_dist_svcdata_DATA = db/postgresql/schema.sql \
+	db/postgresql/update-1.sql
 
 dist_svcweb_DATA = \
 	www/kmtool/kmfooter.php \

--- a/kmtool/db/postgresql/schema.sql
+++ b/kmtool/db/postgresql/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE km_asserted_attribute (
   name VARCHAR NOT NULL,
   value VARCHAR NOT NULL,
   asserter_id UUID,
-  created timestamp DEFAULT NOW()
+  created timestamp DEFAULT NOW() AT TIME ZONE 'UTC'
 );
 
 CREATE INDEX km_asserted_attribute_eppn ON km_asserted_attribute (eppn);

--- a/kmtool/db/postgresql/update-1.sql
+++ b/kmtool/db/postgresql/update-1.sql
@@ -1,0 +1,2 @@
+-- Change default timestamp to be in UTC (and by schema, it drops the time zone)
+ALTER TABLE ONLY km_asserted_attribute ALTER COLUMN created SET DEFAULT NOW() AT TIME ZONE 'UTC';

--- a/lib/php/db-util.php
+++ b/lib/php/db-util.php
@@ -439,7 +439,7 @@ function record_last_seen($user, $request_uri)
   $q_member_id = $conn->quote($user->account_id, 'text');
   $sql = "UPDATE last_seen SET";
   $sql .= " request_uri = " . $q_request_uri;
-  $sql .= ", ts = now()";
+  $sql .= ", ts = now() at time zone 'utc'";
   $sql .= " WHERE member_id = " . $q_member_id;
   $result = db_execute_statement($sql, "record_last_seen update");
   // geni_syslog("UPDATE result = " . print_r($result, true));

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -42,6 +42,7 @@ nobase_dist_svcdata_DATA = \
 	db/postgresql/update-8.sql \
 	db/postgresql/update-9.sql \
 	db/postgresql/update-10.sql \
+	db/postgresql/update-11.sql \
 	gcf.d/example-gcf.ini
 
 #----------------------------------------------------

--- a/portal/db/postgresql/schema.sql
+++ b/portal/db/postgresql/schema.sql
@@ -229,7 +229,7 @@ DROP TABLE IF EXISTS last_seen;
 CREATE TABLE last_seen (
   id SERIAL,
   member_id UUID NOT NULL,
-  ts timestamp not null default CURRENT_TIMESTAMP,
+  ts timestamp not null default NOW() AT TIME ZONE 'UTC',
   request_uri VARCHAR,
   PRIMARY KEY (id)
 );
@@ -271,7 +271,7 @@ CREATE TABLE lead_request (
   requester_urn   VARCHAR NOT NULL,
   requester_uuid  UUID NOT NULL,
   requester_eppn  VARCHAR NOT NULL,
-  request_ts timestamp NOT NULL default CURRENT_TIMESTAMP,
+  request_ts timestamp NOT NULL default NOW() AT TIME ZONE 'UTC',
   approver VARCHAR default '',
   notes VARCHAR default '',
   reason VARCHAR default '',

--- a/portal/db/postgresql/update-11.sql
+++ b/portal/db/postgresql/update-11.sql
@@ -1,0 +1,5 @@
+-- Modify timestamps with a default to use now() but in UTC (not local)
+ALTER TABLE ONLY last_seen ALTER COLUMN ts SET DEFAULT NOW() AT TIME ZONE 'UTC';
+
+ALTER TABLE ONLY lead_request ALTER COLUMN request_ts SET DEFAULT NOW() AT TIME ZONE 'UTC';
+


### PR DESCRIPTION
Make the default for `last_seen` column `ts`, `km_asserted_attribute` column `created` and `lead_request` column `request_ts` be `now() at time zone utc`. And when updating last_seen, also use UTC.

Adds `km/db/postgresql/update-1.sql` and `portal/db/postgresql/update-11.sql`.

Fixes #1446
