### PR TITLE
Silence SQL notices.

### DIFF
--- a/portal/db/postgresql/update-12.sql
+++ b/portal/db/postgresql/update-12.sql
@@ -4,6 +4,12 @@
 -- Record preferences for portal users
 -- ----------------------------------------------------------------------
 
+-- avoid innocuous NOTICEs about automatic sequence creation
+set client_min_messages='WARNING';
+
+-- Tell psql to stop on an error. Default behavior is to proceed.
+\set ON_ERROR_STOP 1
+
 DROP TABLE IF EXISTS user_preferences;
 
 CREATE TABLE user_preferences (


### PR DESCRIPTION
Change SQL warning level to WARNING to avoid innocuous NOTICEs. Set
ON_ERROR_STOP to catch problems early when loading update.