### PR TITLE
Clear local storage when different user logs into portal on same pc.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 == 3.3 ==
  * Store timestamps in UTC for last_seen, lead requests, and KM asserted attributes. (#1446)
  * Update slice table view to match dashboard style
+ * Store username with saved filters/sorts to fix confusion on shared computers (#1477)
  * Add user preferences to the portal (#1526)
   * Allow users to pick a default slice view (#1482)
   * Allow users to pick between default homepage view: cards or table (#1498)

--- a/portal/www/portal/dashboard.js
+++ b/portal/www/portal/dashboard.js
@@ -96,6 +96,12 @@ function save_state(section, selection, sortby) {
 
 // Get the values that you last used and display them
 function resume_dashboard() {
+  if (localStorage.username && localStorage.username != GENI_USERNAME) {
+    localStorage.clear();
+  }
+
+  localStorage.username = GENI_USERNAME;
+
   return_to_prev_state($("#slicefilterswitch"), "lastsliceselection");
   return_to_prev_state($("#slicesortby"), "lastslicesortby");
   return_to_prev_state($("#projectfilterswitch"), "lastprojectselection");

--- a/portal/www/portal/dashboard.php
+++ b/portal/www/portal/dashboard.php
@@ -60,6 +60,9 @@ if (! $user->portalIsAuthorized()) {
 
 show_header('GENI Portal: Home', true, true);
 include("tool-showmessage.php");
+
+echo "<script type='text/javascript'>GENI_USERNAME = '{$user->username}';</script>";
+
 ?>
 
 <script src='dashboard.js'></script>


### PR DESCRIPTION
By storing their username in with their other shared data and checking against it when the dashboard loads. Fixes #1477 