### PR TITLE
Add x button to clear alerts set with $_SESSION['lastmessage']

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 = GENI Portal Release Notes =
 
 == 3.4 ==
-
+ * Add ability to clear success/failure/error messages on pages (#1565)
 
 == 3.3 ==
  * Deploy GENI/ORBIT sync service (geni-sync-wireless.py) and change

--- a/lib/php/tool-showmessage.php
+++ b/lib/php/tool-showmessage.php
@@ -29,10 +29,12 @@ if (! isset($_SESSION)) {
 }
 
 if (isset($_SESSION['lastmessage'])) {
-  print "<p class='instruction'>" . $_SESSION['lastmessage'] . "</p>\n";
+  print "<p class='instruction'>" . $_SESSION['lastmessage'] . " <a onclick='$(this).parent().hide();' class='closebutton'><i class='material-icons'>clear</i></a></p>\n";
   unset($_SESSION['lastmessage']);
 }
 if (isset($_SESSION['lasterror'])) {
-  print "<p class='warn'>" . $_SESSION['lasterror'] . "</p>\n";
+  print "<p class='warn'>" . $_SESSION['lasterror'] . " <a onclick='$(this).parent().hide();' class='closebutton'><i class='material-icons'>clear</i></a></p>\n";
   unset($_SESSION['lasterror']);
 }
+
+?>

--- a/portal/www/common/css/newportal.css
+++ b/portal/www/common/css/newportal.css
@@ -704,7 +704,14 @@ ul.instructions {
   font-style: italic;
 }
 
+.closebutton {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}
+
 .instruction {
+  position: relative;
   background-color: #FFFFFF;
   border-left: 10px solid green;
   color: #616161;
@@ -725,6 +732,7 @@ ul.instructions {
 }
 
 .warn {
+  position: relative;
   background-color: #FFFFFF;
   border-left: 10px solid red;
   color: #616161;
@@ -745,6 +753,7 @@ ul.instructions {
 }
 
 .error {
+  position: relative;
   background-color: #FFFFFF;
   border-left: 10px solid red;
   color: #616161;


### PR DESCRIPTION
i.e. the messages you get which go away on page refresh. 

Ex. "Successfully made project 'test-proj". Fixes #1565