### PR TITLE
Switch to markdown format for CHANGES

### DIFF
--- a/CHANGES-v1.md
+++ b/CHANGES-v1.md
@@ -1,0 +1,289 @@
+# Release 1.9.6
+
+## Issues Closed
+
+* Add ExoGENI FIU and UH racks to service registry ([#714](https://github.com/GENI-NSF/geni-portal/issues/714))
+
+# Release 1.9.5
+
+## Issues Closed
+
+* pgch should log on every call ([#697](https://github.com/GENI-NSF/geni-portal/issues/697))
+* wimax-enable.php should not check for certificates ([#689](https://github.com/GENI-NSF/geni-portal/issues/689))
+* Undefined variable in tool-expired-projects ([#687](https://github.com/GENI-NSF/geni-portal/issues/687))
+* Fix tracebacks in omni_php.py when creating a sliver fails ([#649](https://github.com/GENI-NSF/geni-portal/issues/649))
+* slice expiration datepicker shouldn't let you pick a date past the project expiration ([#614](https://github.com/GENI-NSF/geni-portal/issues/614))
+* Handle error return from omni on create sliver ([#321](https://github.com/GENI-NSF/geni-portal/issues/321))
+
+# Release 1.9.4
+
+## Issues Closed
+
+* log if someone tries to download their outside cert ([#699](https://github.com/GENI-NSF/geni-portal/issues/699))
+
+# Release 1.9.3
+
+## Issues Closed
+
+* pgch is not threadsafe ([#690](https://github.com/GENI-NSF/geni-portal/issues/690))
+
+# Release 1.9.1
+
+## Issues Closed
+
+* produce firstname and lastname fields for GMOC monitoring when IdP does not provide them ([#688](https://github.com/GENI-NSF/geni-portal/issues/688))
+
+# Release 1.9
+
+## Issues Closed
+
+* WiMAX page shows success as failure ([#685](https://github.com/GENI-NSF/geni-portal/issues/685))
+* WiMAX must send 1st ssh key as `sshpublickey` ([#684](https://github.com/GENI-NSF/geni-portal/issues/684))
+* Only show current AM on createsliver page ([#683](https://github.com/GENI-NSF/geni-portal/issues/683))
+* show links for the current aggregate on the Details page ([#682](https://github.com/GENI-NSF/geni-portal/issues/682))
+* rspecview logs the whole rspec ([#680](https://github.com/GENI-NSF/geni-portal/issues/680))
+* delete ssh key result message is ugly ([#679](https://github.com/GENI-NSF/geni-portal/issues/679))
+* update ssh key result message broken ([#678](https://github.com/GENI-NSF/geni-portal/issues/678))
+* valid_expiration undefined ([#677](https://github.com/GENI-NSF/geni-portal/issues/677))
+* pgch createslice fails ([#676](https://github.com/GENI-NSF/geni-portal/issues/676))
+* gemini.php: fails to send private ssh keys ([#674](https://github.com/GENI-NSF/geni-portal/issues/674))
+* add a help link to the irods page ([#673](https://github.com/GENI-NSF/geni-portal/issues/673))
+* repair bitrot in report_genich_relations ([#669](https://github.com/GENI-NSF/geni-portal/issues/669))
+* do-edit-project should check permissions ([#666](https://github.com/GENI-NSF/geni-portal/issues/666))
+* Fix call(s) to modify_project_membership in pa_client.php ([#665](https://github.com/GENI-NSF/geni-portal/issues/665))
+* debug log in rspecupload ([#663](https://github.com/GENI-NSF/geni-portal/issues/663))
+* GIMI OpenID client does not receive response from server ([#661](https://github.com/GENI-NSF/geni-portal/issues/661))
+* Add pa_project_attribute table ([#656](https://github.com/GENI-NSF/geni-portal/issues/656))
+* Allow for download public SSH key ([#655](https://github.com/GENI-NSF/geni-portal/issues/655))
+* update the privacy policy to cover sharing of data with operators via GMOC ([#654](https://github.com/GENI-NSF/geni-portal/issues/654))
+* change links from SignMeUpPortal to SignMeUp ([#653](https://github.com/GENI-NSF/geni-portal/issues/653))
+* pgch needs load balancing ([#650](https://github.com/GENI-NSF/geni-portal/issues/650))
+* undefined variables in amstatus ([#648](https://github.com/GENI-NSF/geni-portal/issues/648))
+* e-mail to identify users in bulk upload should not be case sensitive ([#646](https://github.com/GENI-NSF/geni-portal/issues/646))
+* Login information is wrong in multi-user slices ([#645](https://github.com/GENI-NSF/geni-portal/issues/645))
+* GENI User should be more restrictive ([#644](https://github.com/GENI-NSF/geni-portal/issues/644))
+* Fix sa_url in tool-omniconfig.php ([#643](https://github.com/GENI-NSF/geni-portal/issues/643))
+* Move cainfo.html to ch area ([#642](https://github.com/GENI-NSF/geni-portal/issues/642))
+* Fix warnings in gemini.php ([#641](https://github.com/GENI-NSF/geni-portal/issues/641))
+* create iRODS accounts ([#640](https://github.com/GENI-NSF/geni-portal/issues/640))
+* Default slice expirations ([#636](https://github.com/GENI-NSF/geni-portal/issues/636))
+* Add text next to the request to be a project lead button ([#630](https://github.com/GENI-NSF/geni-portal/issues/630))
+* "Join Project" request can lead to bounced messages ([#629](https://github.com/GENI-NSF/geni-portal/issues/629))
+* Add the email field to the lead request email notification ([#626](https://github.com/GENI-NSF/geni-portal/issues/626))
+* Cleanup `Details` page to only show nodes actually reserved at a particular aggregate ([#605](https://github.com/GENI-NSF/geni-portal/issues/605))
+* Handle DOS et al newlines in bulk add page ([#584](https://github.com/GENI-NSF/geni-portal/issues/584))
+* Merge PA and SA ([#540](https://github.com/GENI-NSF/geni-portal/issues/540))
+* Clean up bulk invite email ([#529](https://github.com/GENI-NSF/geni-portal/issues/529))
+* Support WiMAX sites ([#484](https://github.com/GENI-NSF/geni-portal/issues/484))
+* save error Omni results ([#444](https://github.com/GENI-NSF/geni-portal/issues/444))
+* Handle mistyped email address in Project Join Invitations ([#409](https://github.com/GENI-NSF/geni-portal/issues/409))
+* On text box to invite project members, clarify if text box takes newlines, commas, etc ([#405](https://github.com/GENI-NSF/geni-portal/issues/405))
+* getslicecred GENI AM API call should log something when invoked by an operator ([#397](https://github.com/GENI-NSF/geni-portal/issues/397))
+* Verify OpenID username against clearinghouse data ([#289](https://github.com/GENI-NSF/geni-portal/issues/289))
+* The OpenID login sequence is messy ([#288](https://github.com/GENI-NSF/geni-portal/issues/288))
+
+# Release 1.8
+
+## Issues Closed
+
+* KMTool can't handle capitalized EPPN's that are different from EPPN's in database ([#635](https://github.com/GENI-NSF/geni-portal/issues/635))
+* Portal website refers to incorrect 'footer.php' file ([#633](https://github.com/GENI-NSF/geni-portal/issues/633))
+* import_database should use a tempfile for list of members ([#632](https://github.com/GENI-NSF/geni-portal/issues/632))
+* Update_User_Certs.py does not handle no-key/no-cert case ([#631](https://github.com/GENI-NSF/geni-portal/issues/631))
+* SSH private keys can be duplicated in GEMINI data ([#628](https://github.com/GENI-NSF/geni-portal/issues/628))
+* Conditionalize display of the generate ssh key button on uploadsshkey.php ([#625](https://github.com/GENI-NSF/geni-portal/issues/625))
+* Update GEMINI integration ([#623](https://github.com/GENI-NSF/geni-portal/issues/623))
+* gemini.php is issuing PHP warnings ([#619](https://github.com/GENI-NSF/geni-portal/issues/619))
+* OpenID cannot talk to service registry ([#618](https://github.com/GENI-NSF/geni-portal/issues/618))
+* Modify the "Join the project" default email text ([#616](https://github.com/GENI-NSF/geni-portal/issues/616))
+* handle project request sends email to malformed address ([#611](https://github.com/GENI-NSF/geni-portal/issues/611))
+* ch.geni.net apache config should block portal access ([#590](https://github.com/GENI-NSF/geni-portal/issues/590))
+* tools-admin.php is fake ([#539](https://github.com/GENI-NSF/geni-portal/issues/539))
+* Augment "Details" page with login info for multiple users ([#510](https://github.com/GENI-NSF/geni-portal/issues/510))
+
+# Release 1.7.1
+
+## Issues Closed
+
+* Month expiration date should be incremented by one ([#610](https://github.com/GENI-NSF/geni-portal/issues/610))
+* Add `do-handle-project-request.php` to Makefile.am ([#609](https://github.com/GENI-NSF/geni-portal/issues/609))
+
+# Release 1.7
+
+## Issues Closed
+
+* update_user_certs not robust to user with no portal key ([#606](https://github.com/GENI-NSF/geni-portal/issues/606))
+* Send SSH keys to GEMINI ([#604](https://github.com/GENI-NSF/geni-portal/issues/604))
+* Revamp slice and sliver renewal ([#603](https://github.com/GENI-NSF/geni-portal/issues/603))
+* Add GEMINI button(s) to home page ([#602](https://github.com/GENI-NSF/geni-portal/issues/602))
+* script to reset outside cert ([#601](https://github.com/GENI-NSF/geni-portal/issues/601))
+* Add a note that slice member keys/account will only be adding via the native portal resource reservation mechanism ([#596](https://github.com/GENI-NSF/geni-portal/issues/596))
+* Add an index page for a clearinghouse host ([#595](https://github.com/GENI-NSF/geni-portal/issues/595))
+* Update OpenId for portal.geni.net ([#594](https://github.com/GENI-NSF/geni-portal/issues/594))
+* emails from services have wrong hostname ([#593](https://github.com/GENI-NSF/geni-portal/issues/593))
+* Call setClientCert with an array instead of a string ([#592](https://github.com/GENI-NSF/geni-portal/issues/592))
+* Remove create_standard_services script ([#587](https://github.com/GENI-NSF/geni-portal/issues/587))
+* Add project info to GEMINI data ([#585](https://github.com/GENI-NSF/geni-portal/issues/585))
+* List of project in download omni bundle should only include active projects ([#554](https://github.com/GENI-NSF/geni-portal/issues/554))
+* Add a "delete" ssh key button to Profile page ([#542](https://github.com/GENI-NSF/geni-portal/issues/542))
+* project lead email has empty addressee in body ([#521](https://github.com/GENI-NSF/geni-portal/issues/521))
+* Have raw manifest appear in a window ([#520](https://github.com/GENI-NSF/geni-portal/issues/520))
+* new project page: note lead name is public ([#469](https://github.com/GENI-NSF/geni-portal/issues/469))
+* geni-pgch.log should have timestamps in it ([#398](https://github.com/GENI-NSF/geni-portal/issues/398))
+* Renew slivers when you renew slice ([#126](https://github.com/GENI-NSF/geni-portal/issues/126))
+* Flack does not handle a client certificate chain ([#16](https://github.com/GENI-NSF/geni-portal/issues/16))
+
+# Release 1.6.2
+
+## Issues Closed
+
+* Handle EPPN as case-insensitive ([#597](https://github.com/GENI-NSF/geni-portal/issues/597))
+
+# Release 1.6
+
+## Issues Closed
+
+* import_db clobbers non member logging_entries ([#589](https://github.com/GENI-NSF/geni-portal/issues/589))
+* 2 files not being installed in cs/db ([#586](https://github.com/GENI-NSF/geni-portal/issues/586))
+* notify users to download a new version of omni ([#583](https://github.com/GENI-NSF/geni-portal/issues/583))
+* accept project invite breadcrumbs typo ([#582](https://github.com/GENI-NSF/geni-portal/issues/582))
+* In maintenance mode, allow operators to do more ([#579](https://github.com/GENI-NSF/geni-portal/issues/579))
+* Errors in ch_error.log about /var/www/cainfo.html ([#578](https://github.com/GENI-NSF/geni-portal/issues/578))
+* on DB change, must change member_ids ([#577](https://github.com/GENI-NSF/geni-portal/issues/577))
+* sbin/import_database missing copyright ([#576](https://github.com/GENI-NSF/geni-portal/issues/576))
+* create post-5th intro page for panther ([#575](https://github.com/GENI-NSF/geni-portal/issues/575))
+* Add more scripts to bin install ([#569](https://github.com/GENI-NSF/geni-portal/issues/569))
+* Manage ma_outside_cert table for transition ([#564](https://github.com/GENI-NSF/geni-portal/issues/564))
+* do-register creates ABAC entries that are unused ([#556](https://github.com/GENI-NSF/geni-portal/issues/556))
+
+# Release 1.5
+
+## Issues Closed
+
+* Clarify wording on user cert generation page ([#567](https://github.com/GENI-NSF/geni-portal/issues/567))
+* Make omni-bundle download be the same regardless of the number of projects ([#566](https://github.com/GENI-NSF/geni-portal/issues/566))
+* Split out sundown/lockdown in a branch off of develop ([#565](https://github.com/GENI-NSF/geni-portal/issues/565))
+* Add S/MIME signing to GEMINI data handoff ([#560](https://github.com/GENI-NSF/geni-portal/issues/560))
+* pgch fails to handle renewslice error ([#555](https://github.com/GENI-NSF/geni-portal/issues/555))
+* Update certificate creation instructions to match omni-configure ([#552](https://github.com/GENI-NSF/geni-portal/issues/552))
+* Add `authority` field to omni-bundle and template omni_config ([#551](https://github.com/GENI-NSF/geni-portal/issues/551))
+* Limit max-expiration in preparation for lockdown mode ([#548](https://github.com/GENI-NSF/geni-portal/issues/548))
+* Create and support Portal/CH Lockdown Mode ([#547](https://github.com/GENI-NSF/geni-portal/issues/547))
+* Accept Project Invite page is messy ([#530](https://github.com/GENI-NSF/geni-portal/issues/530))
+* geni-add-trusted-tool has stack trace on failed db authentication ([#505](https://github.com/GENI-NSF/geni-portal/issues/505))
+* install scripts that portal operators run in /usr/local/bin on portals ([#499](https://github.com/GENI-NSF/geni-portal/issues/499))
+* Clean up make install ([#488](https://github.com/GENI-NSF/geni-portal/issues/488))
+* install and shell scripts should get service hostnames from a config file ([#354](https://github.com/GENI-NSF/geni-portal/issues/354))
+* Put SR url in settings.php and use it ([#352](https://github.com/GENI-NSF/geni-portal/issues/352))
+* Eliminate GeniUser->urn() ([#351](https://github.com/GENI-NSF/geni-portal/issues/351))
+
+# Release 1.4
+
+## Issues Closed
+
+* Allow taking away project lead or operator privilege ([#550](https://github.com/GENI-NSF/geni-portal/issues/550))
+* Add a script to revoke privileges ([#549](https://github.com/GENI-NSF/geni-portal/issues/549))
+* copyright missing from tools/stitch_utils.py ([#544](https://github.com/GENI-NSF/geni-portal/issues/544))
+* Slice owner is not updated when Slice Lead is changed ([#537](https://github.com/GENI-NSF/geni-portal/issues/537))
+* Remove debug printouts ([#531](https://github.com/GENI-NSF/geni-portal/issues/531))
+* Project Lead shown on home page (and project page?) is actually the project creator ([#512](https://github.com/GENI-NSF/geni-portal/issues/512))
+* Refresh authority certificates ([#507](https://github.com/GENI-NSF/geni-portal/issues/507))
+* Add a button for GENI Desktop to slice page ([#503](https://github.com/GENI-NSF/geni-portal/issues/503))
+* maintenance mode ([#495](https://github.com/GENI-NSF/geni-portal/issues/495))
+* pgch: implement getversion ([#492](https://github.com/GENI-NSF/geni-portal/issues/492))
+* On portal login page, add link to GPO IdP account request form ([#487](https://github.com/GENI-NSF/geni-portal/issues/487))
+* Implement user lockout for maintenance ([#485](https://github.com/GENI-NSF/geni-portal/issues/485))
+* GENI IdP login formats strange on GEC16 tutorial VM ([#452](https://github.com/GENI-NSF/geni-portal/issues/452))
+
+# Release 1.3
+
+## Issues Closed
+
+* Lead cannot change membership ([#532](https://github.com/GENI-NSF/geni-portal/issues/532))
+* Displayed expired slices on project page but hidden by a button ([#523](https://github.com/GENI-NSF/geni-portal/issues/523))
+* clean up privilege table ([#493](https://github.com/GENI-NSF/geni-portal/issues/493))
+* Start a CHANGELOG ([#489](https://github.com/GENI-NSF/geni-portal/issues/489))
+* Clean up the labels on the aggregate buttons in Flack ([#470](https://github.com/GENI-NSF/geni-portal/issues/470))
+* Undefined HTTP_REFERER in sshkeyedit.php ([#438](https://github.com/GENI-NSF/geni-portal/issues/438))
+* Errors in error.log for new users ([#435](https://github.com/GENI-NSF/geni-portal/issues/435))
+* Sliverstatus error in ready sliver ([#431](https://github.com/GENI-NSF/geni-portal/issues/431))
+* SSH public key identifier says www-data ([#427](https://github.com/GENI-NSF/geni-portal/issues/427))
+* proto-ch make install should put some useful /bin/ scripts into central bin directories ([#426](https://github.com/GENI-NSF/geni-portal/issues/426))
+* Create omni config bundle ([#424](https://github.com/GENI-NSF/geni-portal/issues/424))
+* sa_controller redundancy ([#423](https://github.com/GENI-NSF/geni-portal/issues/423))
+* give AMs consistent short names ([#402](https://github.com/GENI-NSF/geni-portal/issues/402))
+* OpenID authentication results in a connection timed out error ([#396](https://github.com/GENI-NSF/geni-portal/issues/396))
+* slice expiration uses localtime instead of UTC ([#386](https://github.com/GENI-NSF/geni-portal/issues/386))
+* geni-pgch is not logging ([#385](https://github.com/GENI-NSF/geni-portal/issues/385))
+* Slice creation and expiration times are identical ([#384](https://github.com/GENI-NSF/geni-portal/issues/384))
+* Create admin scripts to alter project membership ([#368](https://github.com/GENI-NSF/geni-portal/issues/368))
+* Add project expiration ([#367](https://github.com/GENI-NSF/geni-portal/issues/367))
+* Undefined variables in log file ([#366](https://github.com/GENI-NSF/geni-portal/issues/366))
+* Renewing individual sliver gives error "No new sliver expiration time specified." ([#364](https://github.com/GENI-NSF/geni-portal/issues/364))
+* Update portal_omni_config once gcf-2.2 is release ([#363](https://github.com/GENI-NSF/geni-portal/issues/363))
+* Renew Sliver expiration wrong ([#361](https://github.com/GENI-NSF/geni-portal/issues/361))
+* Make Delete Resources page not be slow ([#358](https://github.com/GENI-NSF/geni-portal/issues/358))
+* Slice status for individual aggregate not updating ([#357](https://github.com/GENI-NSF/geni-portal/issues/357))
+* Does slice page show expired slices? should it? ([#346](https://github.com/GENI-NSF/geni-portal/issues/346))
+* Record portal user last seen timestamp ([#330](https://github.com/GENI-NSF/geni-portal/issues/330))
+* pgch is not restarted on machine reboot ([#326](https://github.com/GENI-NSF/geni-portal/issues/326))
+* Add resources: include all Slice member ssh keys ([#248](https://github.com/GENI-NSF/geni-portal/issues/248))
+* Flack: update to latest ([#233](https://github.com/GENI-NSF/geni-portal/issues/233))
+* support tutorial accounts ([#200](https://github.com/GENI-NSF/geni-portal/issues/200))
+* slice credentials for GMOC staff ([#178](https://github.com/GENI-NSF/geni-portal/issues/178))
+* bulk add to project ([#171](https://github.com/GENI-NSF/geni-portal/issues/171))
+* allow removing members from projects, slices ([#153](https://github.com/GENI-NSF/geni-portal/issues/153))
+* Allow seeing/downloading request RSpecs ([#104](https://github.com/GENI-NSF/geni-portal/issues/104))
+* Allow adding known people to projects/slices ([#86](https://github.com/GENI-NSF/geni-portal/issues/86))
+* Explore shibboleth logout capabilities ([#64](https://github.com/GENI-NSF/geni-portal/issues/64))
+* Construct join/invite pages for slices changes ([#58](https://github.com/GENI-NSF/geni-portal/issues/58))
+* turn off indexing ([#1](https://github.com/GENI-NSF/geni-portal/issues/1))
+
+# Release 1.2
+
+## Issues Closed
+
+* AJAX requests are not handled in parallel due to session management ([#356](https://github.com/GENI-NSF/geni-portal/issues/356))
+* Speed up SliverStatus page ([#355](https://github.com/GENI-NSF/geni-portal/issues/355))
+* Add "use omni" button to slice page ([#345](https://github.com/GENI-NSF/geni-portal/issues/345))
+* If user requests to join one project, the project owner sees requests for the user to join each project ([#344](https://github.com/GENI-NSF/geni-portal/issues/344))
+* Handle users whose IdP does not share an email address ([#341](https://github.com/GENI-NSF/geni-portal/issues/341))
+* Project join email should include url ([#337](https://github.com/GENI-NSF/geni-portal/issues/337))
+* Google Chrome shows HTTPS warning on portal pages ([#335](https://github.com/GENI-NSF/geni-portal/issues/335))
+* Modify portal to support download of `omni_config` with CH ([#334](https://github.com/GENI-NSF/geni-portal/issues/334))
+* e-mail notification of user approval should say who approved the user ([#333](https://github.com/GENI-NSF/geni-portal/issues/333))
+* Change "manifest" to "details" on button label ([#332](https://github.com/GENI-NSF/geni-portal/issues/332))
+* Disable reserve button to prevent multiple presses ([#324](https://github.com/GENI-NSF/geni-portal/issues/324))
+* Use the federated error handler if mail attribute is not available from IdP. ([#318](https://github.com/GENI-NSF/geni-portal/issues/318))
+* Make `pgch` support `listmyslices` ([#317](https://github.com/GENI-NSF/geni-portal/issues/317))
+* Make `pgch` support `RenewSlice` ([#315](https://github.com/GENI-NSF/geni-portal/issues/315))
+* Generate an `omni_config` to use omni with the CH ([#314](https://github.com/GENI-NSF/geni-portal/issues/314))
+* send portal-dev-admin email when user's IdP doesn't share enough ([#308](https://github.com/GENI-NSF/geni-portal/issues/308))
+* log more project changes ([#297](https://github.com/GENI-NSF/geni-portal/issues/297))
+* check project names and slice names for valid URN chars ([#285](https://github.com/GENI-NSF/geni-portal/issues/285))
+* Add Resources page is slow ([#250](https://github.com/GENI-NSF/geni-portal/issues/250))
+* On slice.php Sliver Status for all AMs is slow ([#245](https://github.com/GENI-NSF/geni-portal/issues/245))
+* RSpecs: allow online viewing ([#227](https://github.com/GENI-NSF/geni-portal/issues/227))
+* Add outside key support to KM ([#202](https://github.com/GENI-NSF/geni-portal/issues/202))
+* address coding sprint critiques ([#180](https://github.com/GENI-NSF/geni-portal/issues/180))
+* Sort home page log messages by time ([#119](https://github.com/GENI-NSF/geni-portal/issues/119))
+* Download slice credential page and link ([#85](https://github.com/GENI-NSF/geni-portal/issues/85))
+* Add buttons (and modify pages) to generate createsliver, manifest, and delete pages for one AM ([#81](https://github.com/GENI-NSF/geni-portal/issues/81))
+
+# Release 1.1
+
+## Issues Closed
+
+* Flack fails getting slice credential ([#325](https://github.com/GENI-NSF/geni-portal/issues/325))
+* Internal error on renew slice ([#320](https://github.com/GENI-NSF/geni-portal/issues/320))
+* Project lead email is missing user name ([#316](https://github.com/GENI-NSF/geni-portal/issues/316))
+* Princeton users see a portal error when logging in via InCommon ([#311](https://github.com/GENI-NSF/geni-portal/issues/311))
+* kmactivate page should have a link to the InCommon privacy policy ([#307](https://github.com/GENI-NSF/geni-portal/issues/307))
+* Add resources: awhile to a while ([#305](https://github.com/GENI-NSF/geni-portal/issues/305))
+* modify account: 2 periods ([#304](https://github.com/GENI-NSF/geni-portal/issues/304))
+* Be consistent about project lead request text ([#303](https://github.com/GENI-NSF/geni-portal/issues/303))
+* Delete Resources page has button called Delete Slivers ([#301](https://github.com/GENI-NSF/geni-portal/issues/301))
+* button on Create Project page should say Create ([#300](https://github.com/GENI-NSF/geni-portal/issues/300))
+* Clean up request logic ([#296](https://github.com/GENI-NSF/geni-portal/issues/296))
+* protect handle-project-request ([#295](https://github.com/GENI-NSF/geni-portal/issues/295))
+* omni 2.0 version cache fails on portal ([#203](https://github.com/GENI-NSF/geni-portal/issues/203))

--- a/CHANGES-v2.md
+++ b/CHANGES-v2.md
@@ -1,0 +1,762 @@
+# Release 2.34
+
+## Issues Closed
+
+* Jacks app polls indefinitely if no login information is available ([#1439](https://github.com/GENI-NSF/geni-portal/issues/1439))
+* Ready resources do not colored green on safari ([#1436](https://github.com/GENI-NSF/geni-portal/issues/1436))
+* Redirects on edit-project.php fail to occur after header is printed ([#1434](https://github.com/GENI-NSF/geni-portal/issues/1434))
+* jQuery paths undefined in jfed ([#1426](https://github.com/GENI-NSF/geni-portal/issues/1426))
+* profile should not say you have no slice or lead requests ([#1425](https://github.com/GENI-NSF/geni-portal/issues/1425))
+* Clean up text on do-modify on a duplicate lead request ([#1422](https://github.com/GENI-NSF/geni-portal/issues/1422))
+* Put portal update-9.sql in schema.sql ([#1420](https://github.com/GENI-NSF/geni-portal/issues/1420))
+* Add isManifest=true to Jacks instance in jacks-app ([#1419](https://github.com/GENI-NSF/geni-portal/issues/1419))
+* Createsliver returns error but portal does not realize and says Finished in Green ([#1406](https://github.com/GENI-NSF/geni-portal/issues/1406))
+* ExoSM delete from Jacks App doesn't work ([#1401](https://github.com/GENI-NSF/geni-portal/issues/1401))
+* SSH doesn't work for ExoSM-allocated Nodes ([#1397](https://github.com/GENI-NSF/geni-portal/issues/1397))
+* Map centers at 0,0 on wide screens ([#1390](https://github.com/GENI-NSF/geni-portal/issues/1390))
+* Slice expiration can be erroneously displayed in red ([#1387](https://github.com/GENI-NSF/geni-portal/issues/1387))
+* Delete on Jacks-App creates exponential manifest calls ([#1364](https://github.com/GENI-NSF/geni-portal/issues/1364))
+* Better handling of unknown AMs ([#1346](https://github.com/GENI-NSF/geni-portal/issues/1346))
+* load only 1 version of jquery ([#1327](https://github.com/GENI-NSF/geni-portal/issues/1327))
+* Delete All in Jacks Add Resources does not clear selection dropdown ([#1246](https://github.com/GENI-NSF/geni-portal/issues/1246))
+* Distinguish between 'Finished' and 'Failed' on results page ([#1134](https://github.com/GENI-NSF/geni-portal/issues/1134))
+* Add functionality to operator page on portal ([#1059](https://github.com/GENI-NSF/geni-portal/issues/1059))
+* add operator helper scripts ([#964](https://github.com/GENI-NSF/geni-portal/issues/964))
+* Add Admin page for handling project lead requests ([#731](https://github.com/GENI-NSF/geni-portal/issues/731))
+* Create script to readily see oustanding project lead requests ([#404](https://github.com/GENI-NSF/geni-portal/issues/404))
+* Profile: Make modify real, request project lead ([#273](https://github.com/GENI-NSF/geni-portal/issues/273))
+
+## Pull Requests Merged
+
+* Fix jacks-app looping (PR [#1442](https://github.com/GENI-NSF/geni-portal/pull/1442))
+* Fix redirects when project is successfully created. (PR [#1441](https://github.com/GENI-NSF/geni-portal/pull/1441))
+* Fix issue where jquery paths undefined in tool-jfed (PR [#1427](https://github.com/GENI-NSF/geni-portal/pull/1427))
+* Use common jquery in KM as well. (PR [#1396](https://github.com/GENI-NSF/geni-portal/pull/1396))
+* Use only one version of jQuery (2.1.4) across the portal (#1327) (PR [#1394](https://github.com/GENI-NSF/geni-portal/pull/1394))
+
+# Release 2.33
+
+## Issues Closed
+
+* IRODS VERIFYHOST doesn't work in later versions of CURL ([#1386](https://github.com/GENI-NSF/geni-portal/issues/1386))
+* Use portal keys to add / remove member attributes on wireless page ([#1380](https://github.com/GENI-NSF/geni-portal/issues/1380))
+* Details page loops indefinitely at AL2S ([#1378](https://github.com/GENI-NSF/geni-portal/issues/1378))
+* Show maintenance alerts on all portal pages ([#1375](https://github.com/GENI-NSF/geni-portal/issues/1375))
+* listresources.php gets stuck "...refreshing..." when no resources at an aggregate ([#1365](https://github.com/GENI-NSF/geni-portal/issues/1365))
+* Summarize slice contents on slices / home pages ([#1354](https://github.com/GENI-NSF/geni-portal/issues/1354))
+* Allow retrieving more log messages ([#1318](https://github.com/GENI-NSF/geni-portal/issues/1318))
+* Portal page width doesn't scale with browser width ([#768](https://github.com/GENI-NSF/geni-portal/issues/768))
+
+## Pull Requests Merged
+
+* fixed get_urgency_color bug (PR [#1384](https://github.com/GENI-NSF/geni-portal/pull/1384))
+* Tkt1318 logs (PR [#1382](https://github.com/GENI-NSF/geni-portal/pull/1382))
+* Tkt1354 slicesummary (PR [#1381](https://github.com/GENI-NSF/geni-portal/pull/1381))
+
+# Release 2.32
+
+## Issues Closed
+
+* Remove ION aggregate ([#1377](https://github.com/GENI-NSF/geni-portal/issues/1377))
+* add omni stderr to portal_error log ([#1376](https://github.com/GENI-NSF/geni-portal/issues/1376))
+* Add SAVI button to portal ([#1355](https://github.com/GENI-NSF/geni-portal/issues/1355))
+* loadcert.php delivers expired certificates to xml-signer tool ([#1336](https://github.com/GENI-NSF/geni-portal/issues/1336))
+* Certificate management can be broken after speaks-for authorization ([#1335](https://github.com/GENI-NSF/geni-portal/issues/1335))
+
+# Release 2.31
+
+## Issues Closed
+
+* Rename the Wireless button in the tool section ([#1374](https://github.com/GENI-NSF/geni-portal/issues/1374))
+* wimax-enable missed an error from the server ([#1373](https://github.com/GENI-NSF/geni-portal/issues/1373))
+* Update GENI Desktop link on home page ([#1372](https://github.com/GENI-NSF/geni-portal/issues/1372))
+* "Found no UID in SubjectAltNames" error at RENCI ([#1368](https://github.com/GENI-NSF/geni-portal/issues/1368))
+* Consider adding an "Add GENI Desktop Global Node" button in Jacks App ([#1351](https://github.com/GENI-NSF/geni-portal/issues/1351))
+* Make it easier for Windows users to use keys generated by the Portal. ([#434](https://github.com/GENI-NSF/geni-portal/issues/434))
+
+# Release 2.30
+
+## Issues Closed
+
+* PHP fatal error on double require of logging_client ([#1366](https://github.com/GENI-NSF/geni-portal/issues/1366))
+* Add GEE Button to Home page ([#1363](https://github.com/GENI-NSF/geni-portal/issues/1363))
+* xml-signer does not work with PKCS#8 private keys ([#1362](https://github.com/GENI-NSF/geni-portal/issues/1362))
+* Add new OVS image to Jacks constraints ([#1361](https://github.com/GENI-NSF/geni-portal/issues/1361))
+* Rename assert_email.sh to follow convention with "geni-" prefix, add man page ([#1360](https://github.com/GENI-NSF/geni-portal/issues/1360))
+* update_user_certs broken with new postgresql ([#1359](https://github.com/GENI-NSF/geni-portal/issues/1359))
+* make geni-ch-githash an optional file ([#1358](https://github.com/GENI-NSF/geni-portal/issues/1358))
+* tool-slices undefined index ([#1357](https://github.com/GENI-NSF/geni-portal/issues/1357))
+* Auto add slice users to existing slivers ([#1353](https://github.com/GENI-NSF/geni-portal/issues/1353))
+* Add a json file to the omni bundle to support genilib ([#1352](https://github.com/GENI-NSF/geni-portal/issues/1352))
+* typo on jacks add resources results page ([#1348](https://github.com/GENI-NSF/geni-portal/issues/1348))
+* jacks-lib handle empty rspec ([#1347](https://github.com/GENI-NSF/geni-portal/issues/1347))
+* Remove unused sliverstatus.php ([#1333](https://github.com/GENI-NSF/geni-portal/issues/1333))
+* Jacks app double polls status ([#1326](https://github.com/GENI-NSF/geni-portal/issues/1326))
+* Decorate Different kinds of links (GRE, EGRE, STITCHED) on Jacks ([#1299](https://github.com/GENI-NSF/geni-portal/issues/1299))
+* Make 'stale-omni' an official script ([#1281](https://github.com/GENI-NSF/geni-portal/issues/1281))
+* Joint Manifest/Slice page doesn't refresh login info ([#1280](https://github.com/GENI-NSF/geni-portal/issues/1280))
+* jacks-editor-app.js hard codes a poor context ([#1193](https://github.com/GENI-NSF/geni-portal/issues/1193))
+
+# Release 2.29
+
+## Issues Closed
+
+* Jacks App SSH button replaces current window ([#1344](https://github.com/GENI-NSF/geni-portal/issues/1344))
+* Slow slice jacks blocks other portal pages ([#1343](https://github.com/GENI-NSF/geni-portal/issues/1343))
+* Deprecate Flack ([#1219](https://github.com/GENI-NSF/geni-portal/issues/1219))
+* Make prototype Jacks pages the default for slice, Add Resources ([#1183](https://github.com/GENI-NSF/geni-portal/issues/1183))
+* Warn about illegal RSpecs ([#1101](https://github.com/GENI-NSF/geni-portal/issues/1101))
+* Allow binding or rebinding Nodes ([#1100](https://github.com/GENI-NSF/geni-portal/issues/1100))
+* Handle partially bound RSpecs ([#1088](https://github.com/GENI-NSF/geni-portal/issues/1088))
+* Add a 'Restart' button ([#1044](https://github.com/GENI-NSF/geni-portal/issues/1044))
+* Support bound RSpecs ([#389](https://github.com/GENI-NSF/geni-portal/issues/389))
+
+# Release 2.28
+
+## Issues Closed
+
+* Downloaded RSpec is not in pretty format ([#1340](https://github.com/GENI-NSF/geni-portal/issues/1340))
+* slice-map-data dies if listresources fails on one AM ([#1334](https://github.com/GENI-NSF/geni-portal/issues/1334))
+* Ready fails on slice page ([#1332](https://github.com/GENI-NSF/geni-portal/issues/1332))
+* tool-jfed error when no outside key ([#1331](https://github.com/GENI-NSF/geni-portal/issues/1331))
+* uncaught type error in jacks-app ([#1330](https://github.com/GENI-NSF/geni-portal/issues/1330))
+* Remove unused create-rspec.php ([#1329](https://github.com/GENI-NSF/geni-portal/issues/1329))
+* Duplicate nodes doesn't work if site is set ([#1328](https://github.com/GENI-NSF/geni-portal/issues/1328))
+* null referent in jacks-app.js ([#1325](https://github.com/GENI-NSF/geni-portal/issues/1325))
+* SITE ID shouldn't be changed unless component_manager_id is set ([#1323](https://github.com/GENI-NSF/geni-portal/issues/1323))
+* Duplicate AM's given to stitcher ([#1322](https://github.com/GENI-NSF/geni-portal/issues/1322))
+* Site names on expanded are white not black ([#1321](https://github.com/GENI-NSF/geni-portal/issues/1321))
+* Remove Duplicate nodes/links from jacks editor ([#1320](https://github.com/GENI-NSF/geni-portal/issues/1320))
+* auto_ip doesn't remove original IP's ([#1319](https://github.com/GENI-NSF/geni-portal/issues/1319))
+* Remove site attribute when component_manager_id is set ([#1317](https://github.com/GENI-NSF/geni-portal/issues/1317))
+* Only add compute aggregates to jacks editor list ([#1316](https://github.com/GENI-NSF/geni-portal/issues/1316))
+* duplicate node doesn't work ([#1315](https://github.com/GENI-NSF/geni-portal/issues/1315))
+* Ready status override by multiple status replies ([#1314](https://github.com/GENI-NSF/geni-portal/issues/1314))
+* jacks editor app runs validate rspec file many times ([#1313](https://github.com/GENI-NSF/geni-portal/issues/1313))
+* jacks-editor-app loads jacks twice ([#1312](https://github.com/GENI-NSF/geni-portal/issues/1312))
+* jacks-app-expanded has Expand button and not Back button ([#1310](https://github.com/GENI-NSF/geni-portal/issues/1310))
+* Update Jacks context ([#1298](https://github.com/GENI-NSF/geni-portal/issues/1298))
+* Prettify all rspecs shown in the portal ([#1252](https://github.com/GENI-NSF/geni-portal/issues/1252))
+* Pass jFed slice_urn ([#1210](https://github.com/GENI-NSF/geni-portal/issues/1210))
+
+# Release 2.27
+
+## Issues Closed
+
+* Changes to attributes erased by auto-ip and duplicate-node features ([#1309](https://github.com/GENI-NSF/geni-portal/issues/1309))
+* Remove the warning when pressing slice action buttons on the home page ([#1308](https://github.com/GENI-NSF/geni-portal/issues/1308))
+* Sliverstatus indication on the details page ([#1307](https://github.com/GENI-NSF/geni-portal/issues/1307))
+* Details button on slice-jacks not filtered by sliver_info? ([#1302](https://github.com/GENI-NSF/geni-portal/issues/1302))
+* Context between editor pages doesn't include non-topology changes ([#1301](https://github.com/GENI-NSF/geni-portal/issues/1301))
+* Jacks creation must be in document.ready block ([#1300](https://github.com/GENI-NSF/geni-portal/issues/1300))
+* Highlight name changes with a different email subject ([#1297](https://github.com/GENI-NSF/geni-portal/issues/1297))
+* Infinite loop in duplicate node ([#1296](https://github.com/GENI-NSF/geni-portal/issues/1296))
+* Add new copy/paste to expanded jacks editor as well. ([#1295](https://github.com/GENI-NSF/geni-portal/issues/1295))
+* jacks_editor_app_expanded loses context from jacks_editor_app ([#1292](https://github.com/GENI-NSF/geni-portal/issues/1292))
+* Calls to SCS from portal are delayed by 1 minute ([#1291](https://github.com/GENI-NSF/geni-portal/issues/1291))
+* "Raw" manifest text box doesn't format XML ([#1290](https://github.com/GENI-NSF/geni-portal/issues/1290))
+* list resources doesn't interleave manifests and status properly ([#1289](https://github.com/GENI-NSF/geni-portal/issues/1289))
+* Fix some issues with Jacks viewer/editor and expanded views for 2/4 release ([#1283](https://github.com/GENI-NSF/geni-portal/issues/1283))
+* Support copy/paste in jacks-editor-app ([#1278](https://github.com/GENI-NSF/geni-portal/issues/1278))
+* Allow pgpass or command line arg for db password in map generation scripts ([#1253](https://github.com/GENI-NSF/geni-portal/issues/1253))
+* Set omni2.8 timeout at 45 (minutes) ([#1234](https://github.com/GENI-NSF/geni-portal/issues/1234))
+
+# Release 2.26
+
+## Issues Closed
+
+* Remove get_slice_credential error message from log ([#1288](https://github.com/GENI-NSF/geni-portal/issues/1288))
+* Multiple calls to refresh status adds new elements to status list ([#1286](https://github.com/GENI-NSF/geni-portal/issues/1286))
+* Limit size of downloaded URL ([#1282](https://github.com/GENI-NSF/geni-portal/issues/1282))
+* Error check filenames to upload-file ([#1279](https://github.com/GENI-NSF/geni-portal/issues/1279))
+* Leading space causes RSPEC URL Load to fail ([#1277](https://github.com/GENI-NSF/geni-portal/issues/1277))
+* Details Status Aggregate table should align status label and status value ([#1276](https://github.com/GENI-NSF/geni-portal/issues/1276))
+* Slice details-status with no resources shows no status until details are queried ([#1275](https://github.com/GENI-NSF/geni-portal/issues/1275))
+* Should be able to see raw slice status info from details page. ([#1273](https://github.com/GENI-NSF/geni-portal/issues/1273))
+* Remove warning if affiliation is not present ([#1269](https://github.com/GENI-NSF/geni-portal/issues/1269))
+* Add a Cloud Lab button on home page ([#1267](https://github.com/GENI-NSF/geni-portal/issues/1267))
+* Enhancements to Edit RSpec on Profile page ([#1266](https://github.com/GENI-NSF/geni-portal/issues/1266))
+* Geo Map should be part of tab view as well as full-screen ([#1264](https://github.com/GENI-NSF/geni-portal/issues/1264))
+* Add access to CloudLab from GENI Portal ([#1263](https://github.com/GENI-NSF/geni-portal/issues/1263))
+* Missing scrollbar on View RSpec pane in jacks ([#1248](https://github.com/GENI-NSF/geni-portal/issues/1248))
+* Add new aggregate categories ([#1239](https://github.com/GENI-NSF/geni-portal/issues/1239))
+* Jacks viewer on Manage RSpecs should show menus, sites ([#1237](https://github.com/GENI-NSF/geni-portal/issues/1237))
+* Jacks viewer on Details page should show 'menus' and sites ([#1236](https://github.com/GENI-NSF/geni-portal/issues/1236))
+* Jacks on results page missing RSpec scrollbar ([#1235](https://github.com/GENI-NSF/geni-portal/issues/1235))
+* Allow Jacks app and Jacks editor app to expand with wider browser ([#1233](https://github.com/GENI-NSF/geni-portal/issues/1233))
+* slice jacks ready highlighting broken for ExoSM ([#1231](https://github.com/GENI-NSF/geni-portal/issues/1231))
+* Show sliver expiration in print-rspec-pretty ([#1107](https://github.com/GENI-NSF/geni-portal/issues/1107))
+* Combine the Status and Details pages ([#1043](https://github.com/GENI-NSF/geni-portal/issues/1043))
+* Parse "mail" attribute properly ([#740](https://github.com/GENI-NSF/geni-portal/issues/740))
+
+# Release 2.25
+
+## Issues Closed
+
+* Delete on Jacks-App confusion ([#1265](https://github.com/GENI-NSF/geni-portal/issues/1265))
+* Update copyright year range to include 2015 ([#1261](https://github.com/GENI-NSF/geni-portal/issues/1261))
+* Create GEO MAP view of current slice ([#1260](https://github.com/GENI-NSF/geni-portal/issues/1260))
+* Client ID Assumed to be unique in jacks-app ([#1258](https://github.com/GENI-NSF/geni-portal/issues/1258))
+* Jacks sshes into wrong node when there are duplicate client_ids in a slice ([#1257](https://github.com/GENI-NSF/geni-portal/issues/1257))
+* Name downloaded request rspec with slice name ([#1204](https://github.com/GENI-NSF/geni-portal/issues/1204))
+* Add Jacks editor to Manage RSpecs page ([#1143](https://github.com/GENI-NSF/geni-portal/issues/1143))
+
+# Release 2.24
+
+## Issues Closed
+
+* Host Jacks locally optionally ([#1251](https://github.com/GENI-NSF/geni-portal/issues/1251))
+* Jacks Add Resources says you have to pick an RSpec ([#1249](https://github.com/GENI-NSF/geni-portal/issues/1249))
+* Portal reports "Number of leads for slice must be exactly 1" when adding a member ([#1242](https://github.com/GENI-NSF/geni-portal/issues/1242))
+
+# Release 2.23
+
+## Issues Closed
+
+* Portal crashes looking for GENI_PENDING in get_sliver_status ([#1243](https://github.com/GENI-NSF/geni-portal/issues/1243))
+* Jacks-app delete polls indefinitely ([#1241](https://github.com/GENI-NSF/geni-portal/issues/1241))
+* Some aggregates appear as 0.0 on the map ([#1240](https://github.com/GENI-NSF/geni-portal/issues/1240))
+* Change tab names on slice jacks ([#1238](https://github.com/GENI-NSF/geni-portal/issues/1238))
+* Jacks Add Resources uses stale RSPEC ([#1226](https://github.com/GENI-NSF/geni-portal/issues/1226))
+* Name request rspec in results page with slice name ([#1205](https://github.com/GENI-NSF/geni-portal/issues/1205))
+* Add View RSpec to Jacks Viewer, or equivalent on slice-jacks ([#1202](https://github.com/GENI-NSF/geni-portal/issues/1202))
+* Add a 'clear' button in Jacks Add Resources ([#1191](https://github.com/GENI-NSF/geni-portal/issues/1191))
+* Highlight selected nodes in Jacks ([#1190](https://github.com/GENI-NSF/geni-portal/issues/1190))
+* AM table broken on Slice Jacks ([#1187](https://github.com/GENI-NSF/geni-portal/issues/1187))
+
+# Release 2.22
+
+## Issues Closed
+
+* Change Jacks beta pages to use stable Jacks, not devel ([#1228](https://github.com/GENI-NSF/geni-portal/issues/1228))
+* do-edit-slice-members must check args ([#1224](https://github.com/GENI-NSF/geni-portal/issues/1224))
+* parse multiple services tags ([#1222](https://github.com/GENI-NSF/geni-portal/issues/1222))
+* pending status is unknown ([#1221](https://github.com/GENI-NSF/geni-portal/issues/1221))
+* Increase size of URL textbox ([#1218](https://github.com/GENI-NSF/geni-portal/issues/1218))
+* Move radio buttons to left side of labels on jacks-add-resources ([#1217](https://github.com/GENI-NSF/geni-portal/issues/1217))
+* Update Jacks on sliceresources page ([#1216](https://github.com/GENI-NSF/geni-portal/issues/1216))
+* Do not add to config empty keys list ([#1215](https://github.com/GENI-NSF/geni-portal/issues/1215))
+* am_map functions should call array_key_exists ([#1212](https://github.com/GENI-NSF/geni-portal/issues/1212))
+* Move include files to lib ([#1207](https://github.com/GENI-NSF/geni-portal/issues/1207))
+* createsliver causes 'Undefined property' error ([#1206](https://github.com/GENI-NSF/geni-portal/issues/1206))
+* Rename select from URL to load from URL ([#1201](https://github.com/GENI-NSF/geni-portal/issues/1201))
+* Bug report email mangles AM list ([#1198](https://github.com/GENI-NSF/geni-portal/issues/1198))
+* Headers malformed in email on lead request ([#1197](https://github.com/GENI-NSF/geni-portal/issues/1197))
+* Editing an ssh key results in odd success message ([#973](https://github.com/GENI-NSF/geni-portal/issues/973))
+
+# Release 2.21.4
+
+## Issues Closed
+
+* Edit text on Jacks Add Resources ([#1223](https://github.com/GENI-NSF/geni-portal/issues/1223))
+* "No member URN found for ID: " log messages in KM loadcert ([#1209](https://github.com/GENI-NSF/geni-portal/issues/1209))
+
+# Release 2.21.2
+
+## Issues Closed
+
+* Update the GENI Desktop URLs ([#1199](https://github.com/GENI-NSF/geni-portal/issues/1199))
+* Create an index.php ([#1196](https://github.com/GENI-NSF/geni-portal/issues/1196))
+* Provide a simple Jacks context ([#1194](https://github.com/GENI-NSF/geni-portal/issues/1194))
+
+# Release 2.21
+
+## Issues Closed
+
+* Log message for allocation is ugly ([#1184](https://github.com/GENI-NSF/geni-portal/issues/1184))
+* ReferenceError: Can't find variable: callback when closing rspec viewer ([#1182](https://github.com/GENI-NSF/geni-portal/issues/1182))
+* RSpec View button does nothing ([#1181](https://github.com/GENI-NSF/geni-portal/issues/1181))
+* parseRequestRSpec notice XML load errors ([#1179](https://github.com/GENI-NSF/geni-portal/issues/1179))
+* Protect saverspectoserver ([#1177](https://github.com/GENI-NSF/geni-portal/issues/1177))
+* Undefined offset in getBrowser ([#1176](https://github.com/GENI-NSF/geni-portal/issues/1176))
+* Verify speaks-for signer URN ([#1175](https://github.com/GENI-NSF/geni-portal/issues/1175))
+* Incomplete set of aggregates when selecting slice details from home page ([#1174](https://github.com/GENI-NSF/geni-portal/issues/1174))
+* Parse sliver expiration from FOAM, SFA and GRAM AMs ([#1173](https://github.com/GENI-NSF/geni-portal/issues/1173))
+* email sent from portal does not preserve international characters ([#1162](https://github.com/GENI-NSF/geni-portal/issues/1162))
+* Slice page Jacks prototype ([#1126](https://github.com/GENI-NSF/geni-portal/issues/1126))
+* Handle non-stitching, fully-bound, multi-AM RSpecs ([#1087](https://github.com/GENI-NSF/geni-portal/issues/1087))
+
+# Release 2.20
+
+## Issues Closed
+
+* Allocation page has link to list resources to poll all aggregates ([#1171](https://github.com/GENI-NSF/geni-portal/issues/1171))
+* bug report attachments are inline in Apple Mail ([#1169](https://github.com/GENI-NSF/geni-portal/issues/1169))
+* Rename WiMAX to Wireless ([#1168](https://github.com/GENI-NSF/geni-portal/issues/1168))
+* Send iRODS username to Orbit ([#1167](https://github.com/GENI-NSF/geni-portal/issues/1167))
+* undefined variable ub in util.php getBrowser ([#1166](https://github.com/GENI-NSF/geni-portal/issues/1166))
+* Change slice-wide buttons to poll "this slice" aggregates ([#1165](https://github.com/GENI-NSF/geni-portal/issues/1165))
+* Integrate xml-signer 1.0 ([#1164](https://github.com/GENI-NSF/geni-portal/issues/1164))
+* Integrate omni/gcf 2.7 ([#1163](https://github.com/GENI-NSF/geni-portal/issues/1163))
+* Buttons on per slice rows should act on This Slice ([#1147](https://github.com/GENI-NSF/geni-portal/issues/1147))
+* WiMAX: Send iRODS username ([#1095](https://github.com/GENI-NSF/geni-portal/issues/1095))
+* Portal allows re-uploading an existing Rspec name and description. ([#784](https://github.com/GENI-NSF/geni-portal/issues/784))
+
+# Release 2.19
+
+## Issues Closed
+
+* Add breadcrumbs to Edit SSH Key ([#1161](https://github.com/GENI-NSF/geni-portal/issues/1161))
+* WiMAX: lookup keys using correct user ([#1158](https://github.com/GENI-NSF/geni-portal/issues/1158))
+* typo in user.php ([#1157](https://github.com/GENI-NSF/geni-portal/issues/1157))
+* suppress jfed warning messages ([#1156](https://github.com/GENI-NSF/geni-portal/issues/1156))
+* Renewing at more than 10 aggregates fails ([#1155](https://github.com/GENI-NSF/geni-portal/issues/1155))
+* upload bound RSpec and click reserve gives wrong error message ([#1152](https://github.com/GENI-NSF/geni-portal/issues/1152))
+* WiMAX: Disallow delete group if you lead another group ([#1151](https://github.com/GENI-NSF/geni-portal/issues/1151))
+* properly close img tags ([#1145](https://github.com/GENI-NSF/geni-portal/issues/1145))
+* Display project URN on project page ([#1142](https://github.com/GENI-NSF/geni-portal/issues/1142))
+* name request and manifest rspec as such in tmp dir ([#1132](https://github.com/GENI-NSF/geni-portal/issues/1132))
+* Show the last line of omni stderr to the user ([#1131](https://github.com/GENI-NSF/geni-portal/issues/1131))
+* Filter to AM only for non-stitching requests ([#1130](https://github.com/GENI-NSF/geni-portal/issues/1130))
+* View RSpecs using Jacks viewer ([#1127](https://github.com/GENI-NSF/geni-portal/issues/1127))
+* Remove disabled users from WiMAX groups ([#1124](https://github.com/GENI-NSF/geni-portal/issues/1124))
+* Update to latest xml-signer ([#1116](https://github.com/GENI-NSF/geni-portal/issues/1116))
+* Fork omni/stitcher processes and modify Add Resources results page ([#1106](https://github.com/GENI-NSF/geni-portal/issues/1106))
+* WiMAX: Make new users/groups named geni-foo ([#1094](https://github.com/GENI-NSF/geni-portal/issues/1094))
+* WiMAX: Update to new error codes / methods ([#1093](https://github.com/GENI-NSF/geni-portal/issues/1093))
+* link to jFed ([#1092](https://github.com/GENI-NSF/geni-portal/issues/1092))
+* Support Unicode strings in Portal ([#1069](https://github.com/GENI-NSF/geni-portal/issues/1069))
+* Add privilege check when requesting to view private RSpecs ([#1054](https://github.com/GENI-NSF/geni-portal/issues/1054))
+* Use style sheet on openid/server.php ([#1007](https://github.com/GENI-NSF/geni-portal/issues/1007))
+* Make ajax delete and renew run in parallel ([#998](https://github.com/GENI-NSF/geni-portal/issues/998))
+* RSpecs: store all manifests ([#225](https://github.com/GENI-NSF/geni-portal/issues/225))
+* Add link to request RSpec on slice page ([#165](https://github.com/GENI-NSF/geni-portal/issues/165))
+* Store all request RSpecs ([#164](https://github.com/GENI-NSF/geni-portal/issues/164))
+
+# Release 2.18
+
+## Issues Closed
+
+* Adjust stale-omni to reflect stitcher_php.py ([#1114](https://github.com/GENI-NSF/geni-portal/issues/1114))
+* Allow URL specified GENI Desktop site ([#1113](https://github.com/GENI-NSF/geni-portal/issues/1113))
+* relative redirect on sign in mangles URL ([#1110](https://github.com/GENI-NSF/geni-portal/issues/1110))
+* Add Resources: changing RSpec resets AM ([#1108](https://github.com/GENI-NSF/geni-portal/issues/1108))
+* openid wimax attribute legal names changed ([#1097](https://github.com/GENI-NSF/geni-portal/issues/1097))
+* Project Join Request email subject is grammatically incorrect ([#1083](https://github.com/GENI-NSF/geni-portal/issues/1083))
+* Add several indices and constraints for performance ([#1081](https://github.com/GENI-NSF/geni-portal/issues/1081))
+* create slice page should give error message on missing slice name ([#1028](https://github.com/GENI-NSF/geni-portal/issues/1028))
+* schemas missing constraints ([#943](https://github.com/GENI-NSF/geni-portal/issues/943))
+* It's not clear that the "Raw SliverStatus" link triggers new requests ([#764](https://github.com/GENI-NSF/geni-portal/issues/764))
+* pa_project(project_id) should be declared unique ([#657](https://github.com/GENI-NSF/geni-portal/issues/657))
+* Stitching Allocate Resources Interface ([#581](https://github.com/GENI-NSF/geni-portal/issues/581))
+* Add definition of roles to portal interface ([#558](https://github.com/GENI-NSF/geni-portal/issues/558))
+* Detail pages should mention manifest rspec ([#475](https://github.com/GENI-NSF/geni-portal/issues/475))
+* Make the list of RSpecs be ordered or organized in some way ([#467](https://github.com/GENI-NSF/geni-portal/issues/467))
+* Add new rspec page: explain the fields ([#420](https://github.com/GENI-NSF/geni-portal/issues/420))
+* Add "View RSpec" button on the Add Resources page ([#412](https://github.com/GENI-NSF/geni-portal/issues/412))
+* RSpecs: search function ([#228](https://github.com/GENI-NSF/geni-portal/issues/228))
+
+# Release 2.17
+
+## Issues Closed
+
+* Remove dependence on "pg_manifest" field of sliver status return ([#1084](https://github.com/GENI-NSF/geni-portal/issues/1084))
+* Update to gcf 2.6 ([#1078](https://github.com/GENI-NSF/geni-portal/issues/1078))
+* Implement pushstate history on profile tabs ([#1074](https://github.com/GENI-NSF/geni-portal/issues/1074))
+* Change LabWiki URL ([#1073](https://github.com/GENI-NSF/geni-portal/issues/1073))
+* fix spelling and grammar in "renew your certifcate any time" ([#1072](https://github.com/GENI-NSF/geni-portal/issues/1072))
+* WiMAX delete user fails ([#1068](https://github.com/GENI-NSF/geni-portal/issues/1068))
+* Omni bundle overwrites public keys with the same file name ([#1063](https://github.com/GENI-NSF/geni-portal/issues/1063))
+* PHP date_parse does not have tz_id as a key in the dictionary it returns ([#1061](https://github.com/GENI-NSF/geni-portal/issues/1061))
+* Update link to password reset page ([#1056](https://github.com/GENI-NSF/geni-portal/issues/1056))
+* Pick your IdP page uses http ([#1025](https://github.com/GENI-NSF/geni-portal/issues/1025))
+* Automatically retrieve Ad RSpecs from AMs ([#721](https://github.com/GENI-NSF/geni-portal/issues/721))
+
+# Release 2.16
+
+## Issues Closed
+
+* Slice page does not switch to "This Slice" on Safari ([#1067](https://github.com/GENI-NSF/geni-portal/issues/1067))
+* Table-wide renew calendar gets hidden underneath AMs ([#1057](https://github.com/GENI-NSF/geni-portal/issues/1057))
+* undefined variable ldif_project_name ([#1053](https://github.com/GENI-NSF/geni-portal/issues/1053))
+* Clean up Jacks Viewer implementation ([#1051](https://github.com/GENI-NSF/geni-portal/issues/1051))
+* Clarify slice page wording about user keys being loaded on nodes ([#1050](https://github.com/GENI-NSF/geni-portal/issues/1050))
+* project names and ids are out of sync on wimax-enable ([#1049](https://github.com/GENI-NSF/geni-portal/issues/1049))
+* Add option to Renew Slice and Known Resources on slice page ([#1048](https://github.com/GENI-NSF/geni-portal/issues/1048))
+* Minor fixes to the new slice page ([#1047](https://github.com/GENI-NSF/geni-portal/issues/1047))
+* Change WiMAX orbit LDAP base url ([#1045](https://github.com/GENI-NSF/geni-portal/issues/1045))
+* slice page: add an 'Add' button per AM ([#1042](https://github.com/GENI-NSF/geni-portal/issues/1042))
+* update dragon cert ([#1040](https://github.com/GENI-NSF/geni-portal/issues/1040))
+* Remove precedence and auto-submitted mail headers ([#1039](https://github.com/GENI-NSF/geni-portal/issues/1039))
+* Implement new slice front end ([#1038](https://github.com/GENI-NSF/geni-portal/issues/1038))
+* 2 undefined variables on Details ([#1031](https://github.com/GENI-NSF/geni-portal/issues/1031))
+* add hide raw resource specification ([#1030](https://github.com/GENI-NSF/geni-portal/issues/1030))
+* Profile page uses http for an icon ([#1026](https://github.com/GENI-NSF/geni-portal/issues/1026))
+* Enable WiMAX for all portal users ([#1015](https://github.com/GENI-NSF/geni-portal/issues/1015))
+* Slice page: actions on selected aggregates only ([#958](https://github.com/GENI-NSF/geni-portal/issues/958))
+* Change omni bundle to be called `omni.bundle` ([#929](https://github.com/GENI-NSF/geni-portal/issues/929))
+* Would be nice if I could tell the portal where I had resources ([#762](https://github.com/GENI-NSF/geni-portal/issues/762))
+* RSpecs: Allow editing properties ([#226](https://github.com/GENI-NSF/geni-portal/issues/226))
+* Join a Project table must be sortable, searchable ([#93](https://github.com/GENI-NSF/geni-portal/issues/93))
+
+# Release 2.15
+
+## Issues Closed
+
+* geni-ops-report doesn't handle disabled users ([#1037](https://github.com/GENI-NSF/geni-portal/issues/1037))
+* update dragon cert ([#1033](https://github.com/GENI-NSF/geni-portal/issues/1033))
+* Labwiki kmactivate.php redirect fails ([#1029](https://github.com/GENI-NSF/geni-portal/issues/1029))
+* tool-omniconfig default project doesn't match link ([#1005](https://github.com/GENI-NSF/geni-portal/issues/1005))
+* Files are left in /tmp ([#978](https://github.com/GENI-NSF/geni-portal/issues/978))
+* New account registration does not honor maintenance outage ([#965](https://github.com/GENI-NSF/geni-portal/issues/965))
+* Error for operators during outage with portal de-authorized ([#944](https://github.com/GENI-NSF/geni-portal/issues/944))
+* Display OpenID URL on profile page ([#290](https://github.com/GENI-NSF/geni-portal/issues/290))
+
+# Release 2.14
+
+## Issues Closed
+
+* Allow multiple Jacks windows on listresources ([#1027](https://github.com/GENI-NSF/geni-portal/issues/1027))
+* Wording modifications for ssh generation page ([#1024](https://github.com/GENI-NSF/geni-portal/issues/1024))
+* Wording modifications for the Join a project page ([#1023](https://github.com/GENI-NSF/geni-portal/issues/1023))
+* Incorporate xml-signer 0.7 ([#1022](https://github.com/GENI-NSF/geni-portal/issues/1022))
+* Remove PUBLIC_KEYs from DETAILS_PUBLIC ([#1021](https://github.com/GENI-NSF/geni-portal/issues/1021))
+* Refactor listresources.php page ([#1020](https://github.com/GENI-NSF/geni-portal/issues/1020))
+* details page calls listresources twice ([#1017](https://github.com/GENI-NSF/geni-portal/issues/1017))
+* AM calls failing with php fatal error ([#1016](https://github.com/GENI-NSF/geni-portal/issues/1016))
+* Firefox says "This website does not supply ownership information" for portal.geni.net ([#1014](https://github.com/GENI-NSF/geni-portal/issues/1014))
+* Implement Jacks editor onto an unlinked copy of slice-add-resources.php ([#1013](https://github.com/GENI-NSF/geni-portal/issues/1013))
+* Update the ION AM SSL certificate ([#1012](https://github.com/GENI-NSF/geni-portal/issues/1012))
+* Implement Jacks viewer into listresources.php ([#1011](https://github.com/GENI-NSF/geni-portal/issues/1011))
+* Remove dead scripts ([#999](https://github.com/GENI-NSF/geni-portal/issues/999))
+* Add new link to the portal landing page ([#994](https://github.com/GENI-NSF/geni-portal/issues/994))
+* timeout calls to omni ([#863](https://github.com/GENI-NSF/geni-portal/issues/863))
+
+# Release 2.13
+
+## Issues Closed
+
+* Remove slice expiration as default for sliver renewal ([#1010](https://github.com/GENI-NSF/geni-portal/issues/1010))
+* Provide UI for renewing experimenter certificate ([#241](https://github.com/GENI-NSF/geni-portal/issues/241))
+
+# Release 2.12
+
+## Issues Closed
+
+* quote a log message ([#1003](https://github.com/GENI-NSF/geni-portal/issues/1003))
+* Omni config with no project gives an error ([#1002](https://github.com/GENI-NSF/geni-portal/issues/1002))
+* Update GENI Desktop certificate ([#1001](https://github.com/GENI-NSF/geni-portal/issues/1001))
+* Delete geni-renew-slice ([#997](https://github.com/GENI-NSF/geni-portal/issues/997))
+* Remove readyToLogin.php ([#996](https://github.com/GENI-NSF/geni-portal/issues/996))
+* Represent each GENI site on the map ([#995](https://github.com/GENI-NSF/geni-portal/issues/995))
+* Malformed 'From' field in join related emails ([#988](https://github.com/GENI-NSF/geni-portal/issues/988))
+* Cleanup passphrase temp files ([#979](https://github.com/GENI-NSF/geni-portal/issues/979))
+
+# Release 2.11
+
+## Issues Closed
+
+* Improve speaks-for flow with popup overlay ([#991](https://github.com/GENI-NSF/geni-portal/issues/991))
+* Add 3rd floor Dell rack running GRAM AM into testing infrastructure ([#989](https://github.com/GENI-NSF/geni-portal/issues/989))
+* flack.php sometimes missing a value ([#987](https://github.com/GENI-NSF/geni-portal/issues/987))
+* Update iRODS server cert ([#986](https://github.com/GENI-NSF/geni-portal/issues/986))
+* Add expiration column to support certificate renewal ([#985](https://github.com/GENI-NSF/geni-portal/issues/985))
+* Add starter rack running GRAM AM into testing infrastructure ([#984](https://github.com/GENI-NSF/geni-portal/issues/984))
+* update activate page for citations ([#983](https://github.com/GENI-NSF/geni-portal/issues/983))
+* Flack fails with speaks-for ([#982](https://github.com/GENI-NSF/geni-portal/issues/982))
+* Clean up speaks-for logging ([#981](https://github.com/GENI-NSF/geni-portal/issues/981))
+
+# Release 2.10
+
+## Issues Closed
+
+* tool-omniconfigure always produces v2.3.1 omni_config files ([#980](https://github.com/GENI-NSF/geni-portal/issues/980))
+* Tell experimenters to use Omni 2.5 and chapi framework ([#975](https://github.com/GENI-NSF/geni-portal/issues/975))
+* Change to use omni 2.5 and chapi framework in am calls ([#974](https://github.com/GENI-NSF/geni-portal/issues/974))
+* Pass a default MA to the xml-signer tool ([#972](https://github.com/GENI-NSF/geni-portal/issues/972))
+* Renew Date needs have explicit TZ ([#971](https://github.com/GENI-NSF/geni-portal/issues/971))
+* Portal am_client renew calls should use --alap flag ([#969](https://github.com/GENI-NSF/geni-portal/issues/969))
+* Associate attributes with service registry services ([#968](https://github.com/GENI-NSF/geni-portal/issues/968))
+* AJAX-ify the _slice_ details page ([#465](https://github.com/GENI-NSF/geni-portal/issues/465))
+
+# Release 2.9
+
+## Issues Closed
+
+* Support Common Federation API v2 ([#967](https://github.com/GENI-NSF/geni-portal/issues/967))
+* Pass credentials and options to logging service ([#966](https://github.com/GENI-NSF/geni-portal/issues/966))
+* RSpecs: Allow anonymous rspecs ([#957](https://github.com/GENI-NSF/geni-portal/issues/957))
+* incommon error redirect should do portal logout ([#939](https://github.com/GENI-NSF/geni-portal/issues/939))
+* error-text should have a mailto link for help ([#921](https://github.com/GENI-NSF/geni-portal/issues/921))
+* dont hardcode URNs ([#10](https://github.com/GENI-NSF/geni-portal/issues/10))
+
+# Release 2.8
+
+## Issues Closed
+
+* Add confirm dialog box when renewing resources on a slice ([#963](https://github.com/GENI-NSF/geni-portal/issues/963))
+* map html files should use SERVER_NAME, not HTTP_HOST ([#962](https://github.com/GENI-NSF/geni-portal/issues/962))
+* Show projects and slices in proper case ([#961](https://github.com/GENI-NSF/geni-portal/issues/961))
+* missing copyright in ./portal/www/portal/tool-aggwarning.php ([#960](https://github.com/GENI-NSF/geni-portal/issues/960))
+* Slice page: warn when acting on all aggregates ([#959](https://github.com/GENI-NSF/geni-portal/issues/959))
+* Update flack.php to use new loading mechanism ([#955](https://github.com/GENI-NSF/geni-portal/issues/955))
+* Slice and project expiration times ([#953](https://github.com/GENI-NSF/geni-portal/issues/953))
+
+# Release 2.7
+
+## Issues Closed
+
+* ma_client too verbose on empty list of UIDs ([#954](https://github.com/GENI-NSF/geni-portal/issues/954))
+* Support change to logging service API ([#951](https://github.com/GENI-NSF/geni-portal/issues/951))
+* iRODS server cert expired ([#947](https://github.com/GENI-NSF/geni-portal/issues/947))
+* update copyrights for proto-ch to 2014 ([#945](https://github.com/GENI-NSF/geni-portal/issues/945))
+* Running scripts as MA causes log guard error ([#942](https://github.com/GENI-NSF/geni-portal/issues/942))
+* Pass irods username and zone in Labwiki OpenID payload ([#937](https://github.com/GENI-NSF/geni-portal/issues/937))
+* handle-project-request happily re-handles a handled request ([#926](https://github.com/GENI-NSF/geni-portal/issues/926))
+* Function get_projects_for_member relies on global $user ([#917](https://github.com/GENI-NSF/geni-portal/issues/917))
+* optimize CH queries ([#912](https://github.com/GENI-NSF/geni-portal/issues/912))
+* Add a link to IdP password reset page on the IdP login page ([#904](https://github.com/GENI-NSF/geni-portal/issues/904))
+* Denying project join request should prompt for email text ([#876](https://github.com/GENI-NSF/geni-portal/issues/876))
+* account registration page rejects some passwords ([#756](https://github.com/GENI-NSF/geni-portal/issues/756))
+* Can't add email address to a project via bulk upload ([#713](https://github.com/GENI-NSF/geni-portal/issues/713))
+* Portal/CH mail should attempt to avoid auto-replies ([#686](https://github.com/GENI-NSF/geni-portal/issues/686))
+* portal log_event calls should use $user ([#568](https://github.com/GENI-NSF/geni-portal/issues/568))
+* Add a text box to project bulk add page ([#516](https://github.com/GENI-NSF/geni-portal/issues/516))
+* Properly handle repeated project join requests ([#410](https://github.com/GENI-NSF/geni-portal/issues/410))
+* Handle case where someone invites another person to join a project twice ([#380](https://github.com/GENI-NSF/geni-portal/issues/380))
+* Join requests should probably show up in one page so that you can address all of them at once ([#376](https://github.com/GENI-NSF/geni-portal/issues/376))
+* Manifest page: tweak wording ([#277](https://github.com/GENI-NSF/geni-portal/issues/277))
+
+# Release 2.6.2
+
+## Issues Closed
+
+* parametrize Flack URL ([#941](https://github.com/GENI-NSF/geni-portal/issues/941))
+* Portal fails to handle not authorized ([#940](https://github.com/GENI-NSF/geni-portal/issues/940))
+* portal logout message should say more ([#938](https://github.com/GENI-NSF/geni-portal/issues/938))
+* handle-project-request should check if request is still pending ([#936](https://github.com/GENI-NSF/geni-portal/issues/936))
+* ma_client must not redirect on name lookup errors ([#935](https://github.com/GENI-NSF/geni-portal/issues/935))
+* maintenance mode is only checked on home page ([#934](https://github.com/GENI-NSF/geni-portal/issues/934))
+* privilege scripts should remind you to restart apache ([#933](https://github.com/GENI-NSF/geni-portal/issues/933))
+* chapi client drops client cert chain ([#931](https://github.com/GENI-NSF/geni-portal/issues/931))
+* Authority certificates use incorrect URI format for UUID ([#909](https://github.com/GENI-NSF/geni-portal/issues/909))
+* Certificate error in Flack from emulab.net ([#905](https://github.com/GENI-NSF/geni-portal/issues/905))
+* delete obsolete PHP code ([#898](https://github.com/GENI-NSF/geni-portal/issues/898))
+* portal should forbid changing expired project ([#897](https://github.com/GENI-NSF/geni-portal/issues/897))
+* portal "project join" requests should not impersonate an experimenter's e-mail address ([#879](https://github.com/GENI-NSF/geni-portal/issues/879))
+* Automated emails should set bulk email headers ([#871](https://github.com/GENI-NSF/geni-portal/issues/871))
+* Add a way to determine how you created your SSL cert ([#840](https://github.com/GENI-NSF/geni-portal/issues/840))
+* Move the slice membership table above the AM list ([#819](https://github.com/GENI-NSF/geni-portal/issues/819))
+* Organize list of slices in a project by which are your slices ([#710](https://github.com/GENI-NSF/geni-portal/issues/710))
+
+# Release 2.6.1
+
+## Issues Closed
+
+* geni-enable-user should handle error returns ([#927](https://github.com/GENI-NSF/geni-portal/issues/927))
+* Flack on dev servers doesnt trust the server ([#925](https://github.com/GENI-NSF/geni-portal/issues/925))
+* install geni-enable/disable scripts ([#924](https://github.com/GENI-NSF/geni-portal/issues/924))
+* member attribute scripts should use MA API ([#923](https://github.com/GENI-NSF/geni-portal/issues/923))
+* Add ION AM to portal/CH ([#922](https://github.com/GENI-NSF/geni-portal/issues/922))
+* no copyright in compute_rollback_sql.py ([#920](https://github.com/GENI-NSF/geni-portal/issues/920))
+* clean script usage ([#919](https://github.com/GENI-NSF/geni-portal/issues/919))
+* clean up option in geni-enable-user ([#918](https://github.com/GENI-NSF/geni-portal/issues/918))
+* handle-project-request fails to get email ([#915](https://github.com/GENI-NSF/geni-portal/issues/915))
+* clean up scripts ([#914](https://github.com/GENI-NSF/geni-portal/issues/914))
+
+# Release 2.6
+
+## Issues Closed
+
+* expired projects are in the list for omni default ([#907](https://github.com/GENI-NSF/geni-portal/issues/907))
+* geni-ops-report uses ma_member_privilege ([#903](https://github.com/GENI-NSF/geni-portal/issues/903))
+* undefined index in tool-slices ([#902](https://github.com/GENI-NSF/geni-portal/issues/902))
+* upload-project-members warning ([#901](https://github.com/GENI-NSF/geni-portal/issues/901))
+* newch: do-upload-project-members fails ([#900](https://github.com/GENI-NSF/geni-portal/issues/900))
+* member privilege scripts fail with import error ([#899](https://github.com/GENI-NSF/geni-portal/issues/899))
+* No messages appear on home screen ([#896](https://github.com/GENI-NSF/geni-portal/issues/896))
+* aggregate cache doesn't update ([#895](https://github.com/GENI-NSF/geni-portal/issues/895))
+* ma_create_certificate is not implemented ([#893](https://github.com/GENI-NSF/geni-portal/issues/893))
+* Show pretty name for members on project page ([#892](https://github.com/GENI-NSF/geni-portal/issues/892))
+* kettering-ig-of.pem has cruft line ([#890](https://github.com/GENI-NSF/geni-portal/issues/890))
+* CHAPI result_handler should trim error string ([#889](https://github.com/GENI-NSF/geni-portal/issues/889))
+* compare all booleans using convert_boolean ([#888](https://github.com/GENI-NSF/geni-portal/issues/888))
+* do-handle-project-request does not check inputs ([#886](https://github.com/GENI-NSF/geni-portal/issues/886))
+* WiMAX: ensure non empty givenname ([#885](https://github.com/GENI-NSF/geni-portal/issues/885))
+* Install ca-gpolab.crt in the service_registry ([#884](https://github.com/GENI-NSF/geni-portal/issues/884))
+* CHAPI *_client code doesn't handle exceptions ([#883](https://github.com/GENI-NSF/geni-portal/issues/883))
+* when portal fails to ask CH whether an account exists, portal assumes the account doesn't exist ([#882](https://github.com/GENI-NSF/geni-portal/issues/882))
+* project join approval email cleanup ([#881](https://github.com/GENI-NSF/geni-portal/issues/881))
+* OBE: message_handler gives ugly error on non GET request ([#872](https://github.com/GENI-NSF/geni-portal/issues/872))
+* OBE: /etc/init.d/geni-pgch should set a umask ([#868](https://github.com/GENI-NSF/geni-portal/issues/868))
+* OBE: Remove PA controller from apache config ([#855](https://github.com/GENI-NSF/geni-portal/issues/855))
+* OBE: geni-add-project-member doesn't handle lead role properly ([#854](https://github.com/GENI-NSF/geni-portal/issues/854))
+* log all API calls ([#782](https://github.com/GENI-NSF/geni-portal/issues/782))
+* OBE: message_handler should log on unexpected request type ([#775](https://github.com/GENI-NSF/geni-portal/issues/775))
+* OBE: log message registering SSH key should skip quotes? ([#739](https://github.com/GENI-NSF/geni-portal/issues/739))
+* OBE: project invite accept log message is misleading ([#726](https://github.com/GENI-NSF/geni-portal/issues/726))
+* OBE: traceback in pgch: python bug on failed SSL connections ([#702](https://github.com/GENI-NSF/geni-portal/issues/702))
+* OBE: pgch cert cache will get out of date ([#698](https://github.com/GENI-NSF/geni-portal/issues/698))
+* OBE: Put pgch behind apache ([#672](https://github.com/GENI-NSF/geni-portal/issues/672))
+* OBE: pgch should log source IP ([#651](https://github.com/GENI-NSF/geni-portal/issues/651))
+* OBE: Differentiating MA Attributes ([#647](https://github.com/GENI-NSF/geni-portal/issues/647))
+* OBE: geni-pgch get_ch_version returns a hardcoded version ([#624](https://github.com/GENI-NSF/geni-portal/issues/624))
+* OBE: log pgch to syslog ([#600](https://github.com/GENI-NSF/geni-portal/issues/600))
+* OBE: MA errors on new user setup ([#528](https://github.com/GENI-NSF/geni-portal/issues/528))
+* OBE: Multiple PA functions unguarded ([#502](https://github.com/GENI-NSF/geni-portal/issues/502))
+* OBE: key MA functions unprotected ([#501](https://github.com/GENI-NSF/geni-portal/issues/501))
+* syslog failed authorizations ([#491](https://github.com/GENI-NSF/geni-portal/issues/491))
+* Create a mechanism to disable accounts of people who are behaving badly ([#486](https://github.com/GENI-NSF/geni-portal/issues/486))
+* OBE: pgch shows error messages ([#459](https://github.com/GENI-NSF/geni-portal/issues/459))
+* OBE: undefined index on email_address in ma_utils ([#399](https://github.com/GENI-NSF/geni-portal/issues/399))
+* OBE: put_message should not do an HTTP redirect ([#370](https://github.com/GENI-NSF/geni-portal/issues/370))
+* OBE: request_authorization should return false if action is not authorized ([#369](https://github.com/GENI-NSF/geni-portal/issues/369))
+* OBE: Fix permissions for viewing member slices ([#328](https://github.com/GENI-NSF/geni-portal/issues/328))
+* OBE: Clearinghouse services should catch exceptions and return proper errors ([#319](https://github.com/GENI-NSF/geni-portal/issues/319))
+* OBE: MA must produce user credentials ([#216](https://github.com/GENI-NSF/geni-portal/issues/216))
+* OBE: MA use CSRs internally ([#161](https://github.com/GENI-NSF/geni-portal/issues/161))
+* OBE: merge Credential Store and Authorization service ([#136](https://github.com/GENI-NSF/geni-portal/issues/136))
+* OBE: Make all installs be via packages or config files ([#106](https://github.com/GENI-NSF/geni-portal/issues/106))
+* OBE: Cache reserved resources ([#59](https://github.com/GENI-NSF/geni-portal/issues/59))
+* OBE: gcf-pgch implement Resolve(user) ([#12](https://github.com/GENI-NSF/geni-portal/issues/12))
+* OBE: gcf-pgch check valid uuids ([#11](https://github.com/GENI-NSF/geni-portal/issues/11))
+* OBE: put_message handle HTTP header error codes ([#9](https://github.com/GENI-NSF/geni-portal/issues/9))
+* OBE: *_controller check arguments ([#6](https://github.com/GENI-NSF/geni-portal/issues/6))
+
+# Release 2.5.1
+
+## Issues Closed
+
+* gemini page sending expired projects ([#887](https://github.com/GENI-NSF/geni-portal/issues/887))
+
+# Release 2.5
+
+## Issues Closed
+
+* Revamp the "Modify Account page" ([#877](https://github.com/GENI-NSF/geni-portal/issues/877))
+* add language to stop project doorknob rattling ([#875](https://github.com/GENI-NSF/geni-portal/issues/875))
+* Sort project lists ([#873](https://github.com/GENI-NSF/geni-portal/issues/873))
+* Undefined index in kmcert ([#870](https://github.com/GENI-NSF/geni-portal/issues/870))
+* do-register should check for existing account ([#864](https://github.com/GENI-NSF/geni-portal/issues/864))
+* Change omni configuration instructions to say `omni` not `omni.py` etc ([#862](https://github.com/GENI-NSF/geni-portal/issues/862))
+* wimax: undefined user attributes ([#859](https://github.com/GENI-NSF/geni-portal/issues/859))
+* quiet print-rspec debug ([#858](https://github.com/GENI-NSF/geni-portal/issues/858))
+* Fix error reporting of geni-revoke-member-privileges and geni-remove-project-member ([#853](https://github.com/GENI-NSF/geni-portal/issues/853))
+* PG insists slice names are unique ([#433](https://github.com/GENI-NSF/geni-portal/issues/433))
+
+# Release 2.4
+
+## Issues Closed
+
+* clearing or extending project expiration does not un-expire the project ([#841](https://github.com/GENI-NSF/geni-portal/issues/841))
+* do-renew should forbid times past project expiration ([#839](https://github.com/GENI-NSF/geni-portal/issues/839))
+* Add project expiration time in the slice view ([#838](https://github.com/GENI-NSF/geni-portal/issues/838))
+* Remove idp account request pages ([#837](https://github.com/GENI-NSF/geni-portal/issues/837))
+* print rspec pretty errors in logs ([#836](https://github.com/GENI-NSF/geni-portal/issues/836))
+* irods: remove project members from irods group when removed from project ([#832](https://github.com/GENI-NSF/geni-portal/issues/832))
+* irods: add project members to irods groups ([#831](https://github.com/GENI-NSF/geni-portal/issues/831))
+* irods: create irods group for each project ([#830](https://github.com/GENI-NSF/geni-portal/issues/830))
+* irods: refactor basic stuff to an irods_utils ([#829](https://github.com/GENI-NSF/geni-portal/issues/829))
+* openid AX to labwiki has an error ([#828](https://github.com/GENI-NSF/geni-portal/issues/828))
+* Rationalize the Profile tabs ([#812](https://github.com/GENI-NSF/geni-portal/issues/812))
+* Rspecs in user Profile ([#810](https://github.com/GENI-NSF/geni-portal/issues/810))
+* clean up geni-revoke-member-permission ([#716](https://github.com/GENI-NSF/geni-portal/issues/716))
+* Cert generation and download links outside of Omni ([#708](https://github.com/GENI-NSF/geni-portal/issues/708))
+* geni_revoke_member_privilege doesnt for operators ([#668](https://github.com/GENI-NSF/geni-portal/issues/668))
+* Make slice member names be mailto links on slice page ([#538](https://github.com/GENI-NSF/geni-portal/issues/538))
+
+# Release 2.3
+
+## Issues Closed
+
+* OpenID: Fatal error calling undefined method Auth_OpenID_AX_Error::iterTypes() ([#827](https://github.com/GENI-NSF/geni-portal/issues/827))
+* Add LabWiki button ([#825](https://github.com/GENI-NSF/geni-portal/issues/825))
+* Different details view for EG and IG ([#823](https://github.com/GENI-NSF/geni-portal/issues/823))
+* Make "Generate SSL cert" button open in a new tab ([#822](https://github.com/GENI-NSF/geni-portal/issues/822))
+* Add slice name instructions in the create slice page ([#821](https://github.com/GENI-NSF/geni-portal/issues/821))
+* link rspec printing broken ([#818](https://github.com/GENI-NSF/geni-portal/issues/818))
+* report_genich_relations reports slice creation and expiration in wrong timezone ([#817](https://github.com/GENI-NSF/geni-portal/issues/817))
+* Pass additional info in OpenID data ([#813](https://github.com/GENI-NSF/geni-portal/issues/813))
+* Alphabetize members in Project ([#811](https://github.com/GENI-NSF/geni-portal/issues/811))
+* WiMAX: Support openid ([#809](https://github.com/GENI-NSF/geni-portal/issues/809))
+* WiMAX: Support changing project lead ([#808](https://github.com/GENI-NSF/geni-portal/issues/808))
+* WiMAX: Allow project leads to enable multiple WiMAX groups ([#807](https://github.com/GENI-NSF/geni-portal/issues/807))
+* WiMAX: Allow deleting groups ([#806](https://github.com/GENI-NSF/geni-portal/issues/806))
+* WiMAX: Allow deleting group members ([#805](https://github.com/GENI-NSF/geni-portal/issues/805))
+* renew should assume 23:59:59 ([#796](https://github.com/GENI-NSF/geni-portal/issues/796))
+* WiMAX: Support error codes ([#777](https://github.com/GENI-NSF/geni-portal/issues/777))
+* WiMAX: how do we handle duplicate usernames? ([#776](https://github.com/GENI-NSF/geni-portal/issues/776))
+* WiMAX: Support changing projects ([#774](https://github.com/GENI-NSF/geni-portal/issues/774))
+* WiMAX: change URL ([#771](https://github.com/GENI-NSF/geni-portal/issues/771))
+* remove Add Note function on slice and project pages ([#728](https://github.com/GENI-NSF/geni-portal/issues/728))
+* clean up geni-remove-from-project ([#715](https://github.com/GENI-NSF/geni-portal/issues/715))
+* Clean up OpenID logging ([#670](https://github.com/GENI-NSF/geni-portal/issues/670))
+
+# Release 2.2
+
+## Issues Closed
+
+* log when printing rspec skips non-local nodes ([#803](https://github.com/GENI-NSF/geni-portal/issues/803))
+* upload-project-members must handle empty file ([#802](https://github.com/GENI-NSF/geni-portal/issues/802))
+* Comment out ROWS debug log ([#798](https://github.com/GENI-NSF/geni-portal/issues/798))
+* Make GENI username more visible ([#797](https://github.com/GENI-NSF/geni-portal/issues/797))
+* new code for printing out SSHA hashes for the wiki inserts too much whitespace ([#795](https://github.com/GENI-NSF/geni-portal/issues/795))
+* Update portal to use gcf-2.4 final ([#794](https://github.com/GENI-NSF/geni-portal/issues/794))
+* GENI Portal has incorrect company name in copyright label ([#793](https://github.com/GENI-NSF/geni-portal/issues/793))
+* print-text-helpers php warnings ([#791](https://github.com/GENI-NSF/geni-portal/issues/791))
+* PHP warning on error_log in ma_controller ([#790](https://github.com/GENI-NSF/geni-portal/issues/790))
+* There is no version information in the GENI portal ([#789](https://github.com/GENI-NSF/geni-portal/issues/789))
+* Slice listing needs sorting in portal ([#788](https://github.com/GENI-NSF/geni-portal/issues/788))
+* ExoGENI hostname shows empty on details page ([#767](https://github.com/GENI-NSF/geni-portal/issues/767))
+* Alphabetize RSpecs and label public and private RSpecs ([#761](https://github.com/GENI-NSF/geni-portal/issues/761))
+* Send an email to experimenter when they request to be a project lead ([#760](https://github.com/GENI-NSF/geni-portal/issues/760))
+* Rephrase Omni Configuration instructions ([#753](https://github.com/GENI-NSF/geni-portal/issues/753))
+* use code format on irods page ([#744](https://github.com/GENI-NSF/geni-portal/issues/744))
+* Use the word "portal" on the portal.geni.net landing page ([#733](https://github.com/GENI-NSF/geni-portal/issues/733))
+* Lack of component_manager_id causes manifests to not be displayed for ExoSM ([#712](https://github.com/GENI-NSF/geni-portal/issues/712))
+* Should be able to see key fingerprints from portal UI ([#695](https://github.com/GENI-NSF/geni-portal/issues/695))
+* Status on Expired Slice ([#675](https://github.com/GENI-NSF/geni-portal/issues/675))
+* Fix message on the portal when followin an approval link ([#617](https://github.com/GENI-NSF/geni-portal/issues/617))
+* Update some links from portal-help to help ([#572](https://github.com/GENI-NSF/geni-portal/issues/572))
+* Add the ability to load Project Admins/Members onto slices by default ([#559](https://github.com/GENI-NSF/geni-portal/issues/559))
+* Add a refresh button in sliver status page ([#451](https://github.com/GENI-NSF/geni-portal/issues/451))
+* Clean up files in /tmp ([#383](https://github.com/GENI-NSF/geni-portal/issues/383))
+
+# Release 2.1
+
+## Issues Closed
+
+* rspec upload errors in logs ([#781](https://github.com/GENI-NSF/geni-portal/issues/781))
+* Update Map RSpec data for new RSpecs ([#780](https://github.com/GENI-NSF/geni-portal/issues/780))
+* Add IG GPO OF and GPO OF AM install files ([#779](https://github.com/GENI-NSF/geni-portal/issues/779))
+* Federated error handling is broken ([#778](https://github.com/GENI-NSF/geni-portal/issues/778))
+* undefined HTTP_HOST in map-small.html ([#755](https://github.com/GENI-NSF/geni-portal/issues/755))
+* add new GPO sandbox portal/CH nodes to proto-ch git ([#745](https://github.com/GENI-NSF/geni-portal/issues/745))
+* Revise handling of Google Analytics ([#742](https://github.com/GENI-NSF/geni-portal/issues/742))
+* shib_idp_users should output pw hash in backticks ([#732](https://github.com/GENI-NSF/geni-portal/issues/732))
+* non project member can load project page ([#727](https://github.com/GENI-NSF/geni-portal/issues/727))
+* RSpec upload page not robust to bad RSpecs ([#720](https://github.com/GENI-NSF/geni-portal/issues/720))
+* Undefined variable: ams in amstatus ([#692](https://github.com/GENI-NSF/geni-portal/issues/692))
+* download SSH public key from downloaded pair filename should end in .pub ([#681](https://github.com/GENI-NSF/geni-portal/issues/681))
+* SA allows members or auditors to edit slice membership ([#533](https://github.com/GENI-NSF/geni-portal/issues/533))
+* Make order of aggregates consistent ([#478](https://github.com/GENI-NSF/geni-portal/issues/478))
+* Sliver status returns error for AMs with no resources ([#429](https://github.com/GENI-NSF/geni-portal/issues/429))
+* Add new rspec page: should new rspecs be public by default? ([#421](https://github.com/GENI-NSF/geni-portal/issues/421))
+* Update portal to use gcf-2.4 ([#392](https://github.com/GENI-NSF/geni-portal/issues/392))
+* remove pgch once gcf updated ([#347](https://github.com/GENI-NSF/geni-portal/issues/347))
+* Fix hardcoded hostname in openid configuration files ([#287](https://github.com/GENI-NSF/geni-portal/issues/287))
+
+# Release 2.0
+
+## Issues Closed
+
+* Fix Google Analytics string to be a global variable ([#743](https://github.com/GENI-NSF/geni-portal/issues/743))
+* clean up example admin address used in etc/settings.php ([#741](https://github.com/GENI-NSF/geni-portal/issues/741))
+* Add Resources page should include tool-showmessage ([#738](https://github.com/GENI-NSF/geni-portal/issues/738))
+* Fix minor bugs in new portal CSS ([#737](https://github.com/GENI-NSF/geni-portal/issues/737))
+* Don't install advertisement RSpecs and map.php ([#736](https://github.com/GENI-NSF/geni-portal/issues/736))
+* No copyright in './portal/www/portal/map.php' ([#735](https://github.com/GENI-NSF/geni-portal/issues/735))
+* Create GENI resource map for monitor display ([#734](https://github.com/GENI-NSF/geni-portal/issues/734))
+* Remove fake slice email from slice certificates ([#729](https://github.com/GENI-NSF/geni-portal/issues/729))
+* Add Google Analytics functionality ([#718](https://github.com/GENI-NSF/geni-portal/issues/718))
+* Update the portal's CSS ([#717](https://github.com/GENI-NSF/geni-portal/issues/717))
+* Profile RSpecs section should say RSpec ([#707](https://github.com/GENI-NSF/geni-portal/issues/707))
+* add ToC on profile page ([#706](https://github.com/GENI-NSF/geni-portal/issues/706))
+* Move glossary from portal to GENI public wiki. ([#703](https://github.com/GENI-NSF/geni-portal/issues/703))
+* script to add ma_member_attribute ([#701](https://github.com/GENI-NSF/geni-portal/issues/701))
+* write a standalone script to determine which people in a provided list have portal accounts ([#700](https://github.com/GENI-NSF/geni-portal/issues/700))
+* enable VERIFYHOST in put_message ([#660](https://github.com/GENI-NSF/geni-portal/issues/660))
+* Fix Slice/Project Membership functionality according to recent feedback ([#496](https://github.com/GENI-NSF/geni-portal/issues/496))
+* Can't look at a slice I'm not a member of, but can see it from projects page ([#442](https://github.com/GENI-NSF/geni-portal/issues/442))
+* Make button-like things be buttons ([#175](https://github.com/GENI-NSF/geni-portal/issues/175))
+* Create interactive map of resources ([#28](https://github.com/GENI-NSF/geni-portal/issues/28))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,174 @@
+# Release 3.4
+
+## Issues Closed
+
+* Add ability to set default homepage tab ([#1579](https://github.com/GENI-NSF/geni-portal/issues/1579))
+* Users get stuck in confusing state if they're in no active projects. ([#1567](https://github.com/GENI-NSF/geni-portal/issues/1567))
+* Add ability to clear "last message" ([#1565](https://github.com/GENI-NSF/geni-portal/issues/1565))
+* Add version to local storage  ([#1479](https://github.com/GENI-NSF/geni-portal/issues/1479))
+* On admin page slice search, show member usernames ([#1432](https://github.com/GENI-NSF/geni-portal/issues/1432))
+* Some error messages are page redirects on the admin page ([#1417](https://github.com/GENI-NSF/geni-portal/issues/1417))
+
+## Pull Requests Merged
+
+* Add geni-sync-wireless to doc (PR [#1586](https://github.com/GENI-NSF/geni-portal/pull/1586))
+* Improve error handling for failed slice searches on admin page. (PR [#1585](https://github.com/GENI-NSF/geni-portal/pull/1585))
+* Move man page to geni-ch (PR [#1584](https://github.com/GENI-NSF/geni-portal/pull/1584))
+* Add user preference for picking default homepage tab. (PR [#1583](https://github.com/GENI-NSF/geni-portal/pull/1583))
+* Show name and username when listing slice members on slice search. (PR [#1582](https://github.com/GENI-NSF/geni-portal/pull/1582))
+* Change what displays when a user has no active projects. (PR [#1581](https://github.com/GENI-NSF/geni-portal/pull/1581))
+* Add x button to clear alerts set with $_SESSION['lastmessage'] (PR [#1578](https://github.com/GENI-NSF/geni-portal/pull/1578))
+* Add version number to local storage and clear Ls when this changes. (PR [#1577](https://github.com/GENI-NSF/geni-portal/pull/1577))
+* Bump version to 3.4 (PR [#1575](https://github.com/GENI-NSF/geni-portal/pull/1575))
+* Migrate scripts to geni-ch (PR [#1413](https://github.com/GENI-NSF/geni-portal/pull/1413))
+
+# Release 3.3
+
+## Issues Closed
+
+* Add a secondary sort for slices ([#1560](https://github.com/GENI-NSF/geni-portal/issues/1560))
+* Footer is different width than the normal content. ([#1555](https://github.com/GENI-NSF/geni-portal/issues/1555))
+* Add user preferences ([#1526](https://github.com/GENI-NSF/geni-portal/issues/1526))
+* Check portalIsAuthorized earlier in dashboard.php ([#1506](https://github.com/GENI-NSF/geni-portal/issues/1506))
+* Bring back the slice list ([#1498](https://github.com/GENI-NSF/geni-portal/issues/1498))
+* Would like an option for default slice view ([#1482](https://github.com/GENI-NSF/geni-portal/issues/1482))
+* dashboard storage is confused on shared computers ([#1477](https://github.com/GENI-NSF/geni-portal/issues/1477))
+* TZ on lead requests is wrong ([#1446](https://github.com/GENI-NSF/geni-portal/issues/1446))
+* Support new model for wireless accounts ([#1392](https://github.com/GENI-NSF/geni-portal/issues/1392))
+* WiMAX: forbid delete your group when you lead another group ([#1136](https://github.com/GENI-NSF/geni-portal/issues/1136))
+* WiMAX: Add state sync functions ([#1076](https://github.com/GENI-NSF/geni-portal/issues/1076))
+* WiMAX: Inconsistent DB state ([#1058](https://github.com/GENI-NSF/geni-portal/issues/1058))
+* WiMAX: Support multiple wimax sites ([#773](https://github.com/GENI-NSF/geni-portal/issues/773))
+* WiMAX: Put URL in service registry ([#772](https://github.com/GENI-NSF/geni-portal/issues/772))
+
+## Pull Requests Merged
+
+* Clear local storage when different user logs into portal on same pc. (PR [#1574](https://github.com/GENI-NSF/geni-portal/pull/1574))
+* Use slice/project name to break ties when sorting. (PR [#1573](https://github.com/GENI-NSF/geni-portal/pull/1573))
+* Dashboard code cleanup (PR [#1572](https://github.com/GENI-NSF/geni-portal/pull/1572))
+* Make footer width match width of other cards (PR [#1571](https://github.com/GENI-NSF/geni-portal/pull/1571))
+* Silence SQL notices. (PR [#1570](https://github.com/GENI-NSF/geni-portal/pull/1570))
+* Add preference for default tab on the slice page.  (PR [#1568](https://github.com/GENI-NSF/geni-portal/pull/1568))
+* Update slice table view (PR [#1566](https://github.com/GENI-NSF/geni-portal/pull/1566))
+* Use UTC for database timestamps (PR [#1564](https://github.com/GENI-NSF/geni-portal/pull/1564))
+* Update Jacks context file (PR [#1563](https://github.com/GENI-NSF/geni-portal/pull/1563))
+* bump to 3.3 (PR [#1559](https://github.com/GENI-NSF/geni-portal/pull/1559))
+* Add user preferences to portal. (PR [#1556](https://github.com/GENI-NSF/geni-portal/pull/1556))
+* Wireless integration between GENI and ORBIT (PR [#1532](https://github.com/GENI-NSF/geni-portal/pull/1532))
+
+# Release 3.2
+
+## Issues Closed
+
+* Logs on slice and project page can timeout ([#1557](https://github.com/GENI-NSF/geni-portal/issues/1557))
+* Lots of dead code in header.php ([#1553](https://github.com/GENI-NSF/geni-portal/issues/1553))
+* last_seen table is not being populated ([#1550](https://github.com/GENI-NSF/geni-portal/issues/1550))
+* Renew doesn't work on (new) slice page ([#1549](https://github.com/GENI-NSF/geni-portal/issues/1549))
+* Allow for switching between arbitrary cards in cards.js ([#1545](https://github.com/GENI-NSF/geni-portal/issues/1545))
+* Cards file has hardcoded reference to map tab for map initialization ([#1544](https://github.com/GENI-NSF/geni-portal/issues/1544))
+* PHP warning in logs for admin page ([#1535](https://github.com/GENI-NSF/geni-portal/issues/1535))
+* Add link to projects tab from new slice page when not in any projects ([#1524](https://github.com/GENI-NSF/geni-portal/issues/1524))
+* Replace user name with "User" when load_user is false in show_header ([#1519](https://github.com/GENI-NSF/geni-portal/issues/1519))
+* Aggregate view on slice page has lost its styling ([#1518](https://github.com/GENI-NSF/geni-portal/issues/1518))
+* Alerts look bad with new header design ([#1516](https://github.com/GENI-NSF/geni-portal/issues/1516))
+* Update project page to match dashboard ([#1514](https://github.com/GENI-NSF/geni-portal/issues/1514))
+* Update profile page to match dashboard ([#1513](https://github.com/GENI-NSF/geni-portal/issues/1513))
+* Make project name on slice card a link to the project ([#1512](https://github.com/GENI-NSF/geni-portal/issues/1512))
+* Make "N slices" on project card be a link to those slices ([#1511](https://github.com/GENI-NSF/geni-portal/issues/1511))
+* Update slice page to match dashboard ([#1509](https://github.com/GENI-NSF/geni-portal/issues/1509))
+* Need to be able to sort slices by project ([#1497](https://github.com/GENI-NSF/geni-portal/issues/1497))
+* Logs pane embeds login page if session times out ([#1460](https://github.com/GENI-NSF/geni-portal/issues/1460))
+
+## Pull Requests Merged
+
+* Fix bug where login page gets embedded on slices & projects log tabs on session timeout (PR [#1558](https://github.com/GENI-NSF/geni-portal/pull/1558))
+* Clean up code in header.php, remove references to old header tabs (PR [#1554](https://github.com/GENI-NSF/geni-portal/pull/1554))
+* Fix issue where "last_seen" table was not being populated (PR [#1552](https://github.com/GENI-NSF/geni-portal/pull/1552))
+* Fixed broken renew button on the (new) slice page (PR [#1551](https://github.com/GENI-NSF/geni-portal/pull/1551))
+* Make "has n slices" a link to the slice card showing those slices (PR [#1547](https://github.com/GENI-NSF/geni-portal/pull/1547))
+* Clean up cards.js code, add ability to switch to arbitrary card (PR [#1546](https://github.com/GENI-NSF/geni-portal/pull/1546))
+* Fix bug where login screen gets embedded in logs card on session timeout (PR [#1543](https://github.com/GENI-NSF/geni-portal/pull/1543))
+* Show links to profile pages even when $load_user is false (PR [#1542](https://github.com/GENI-NSF/geni-portal/pull/1542))
+* Add link to projects tab from new slice page when not in any projects. (PR [#1541](https://github.com/GENI-NSF/geni-portal/pull/1541))
+* Make project names on slice cards a link to that project (PR [#1540](https://github.com/GENI-NSF/geni-portal/pull/1540))
+* Fix formatting of the aggregate view on the slice page (PR [#1539](https://github.com/GENI-NSF/geni-portal/pull/1539))
+* Fix php warnings about undefined indices on admin page (PR [#1538](https://github.com/GENI-NSF/geni-portal/pull/1538))
+* Allow for sorting of slices by project name on dashboard. (PR [#1536](https://github.com/GENI-NSF/geni-portal/pull/1536))
+* Update project page to use new tab/cards style  (PR [#1534](https://github.com/GENI-NSF/geni-portal/pull/1534))
+* Update slice page to match dashboard tab navigation (PR [#1533](https://github.com/GENI-NSF/geni-portal/pull/1533))
+* Bump version to 3.2 (PR [#1530](https://github.com/GENI-NSF/geni-portal/pull/1530))
+* Make tabs on the profile page match those on the dashboard. (PR [#1528](https://github.com/GENI-NSF/geni-portal/pull/1528))
+* Make maintenance alerts appear as their own card above content. (PR [#1520](https://github.com/GENI-NSF/geni-portal/pull/1520))
+* Migrate aggregates to geni-ch (PR [#1412](https://github.com/GENI-NSF/geni-portal/pull/1412))
+
+# Release 3.1.1
+
+## Issues Closed
+
+* Deleted files appear in Makefiles ([#1531](https://github.com/GENI-NSF/geni-portal/issues/1531))
+
+# Release 3.1
+
+## Issues Closed
+
+* Add a GENI bibliography link on the Help menu  ([#1510](https://github.com/GENI-NSF/geni-portal/issues/1510))
+* Add google analytics to flack page ([#1504](https://github.com/GENI-NSF/geni-portal/issues/1504))
+* Hamburger menu pops up on mobile on page resize ([#1500](https://github.com/GENI-NSF/geni-portal/issues/1500))
+* Add a link to geni-lib under Tools menu ([#1491](https://github.com/GENI-NSF/geni-portal/issues/1491))
+* Add google analytics to "expanded view" pages. ([#1488](https://github.com/GENI-NSF/geni-portal/issues/1488))
+* Make projects.php redirect to projects tab on the dashboard. ([#1487](https://github.com/GENI-NSF/geni-portal/issues/1487))
+* Add "contact us" page and link to it under "Help" dropdown. ([#1486](https://github.com/GENI-NSF/geni-portal/issues/1486))
+* Indenting/ CSS of SSH key instructions on SSH tab is confusing ([#1485](https://github.com/GENI-NSF/geni-portal/issues/1485))
+* Project cards grow on text overflow, making weird gaps on project tab. ([#1484](https://github.com/GENI-NSF/geni-portal/issues/1484))
+* Renew slice button on dashboard pops up incorrect warning about too many aggregates ([#1481](https://github.com/GENI-NSF/geni-portal/issues/1481))
+* Fix styling on expanded Jacks pages ([#1458](https://github.com/GENI-NSF/geni-portal/issues/1458))
+* Add an Other Tools page ([#1457](https://github.com/GENI-NSF/geni-portal/issues/1457))
+* GEO View only shows half on first display ([#1272](https://github.com/GENI-NSF/geni-portal/issues/1272))
+
+## Pull Requests Merged
+
+* Add link to GENI Bibliography (PR [#1515](https://github.com/GENI-NSF/geni-portal/pull/1515))
+* Add google analytics to flack page (PR [#1505](https://github.com/GENI-NSF/geni-portal/pull/1505))
+* Fix bug where hamburger menu would expand on every page resize. (PR [#1503](https://github.com/GENI-NSF/geni-portal/pull/1503))
+* Fix styling of Jacks expanded views. (PR [#1502](https://github.com/GENI-NSF/geni-portal/pull/1502))
+* Update welcome page to use new portal CSS styles. (PR [#1501](https://github.com/GENI-NSF/geni-portal/pull/1501))
+* Add Google analytics (via adding header) to jacks-expanded views. (PR [#1499](https://github.com/GENI-NSF/geni-portal/pull/1499))
+* Fix formatting on the SSH tab of the profile page to be clearer (PR [#1496](https://github.com/GENI-NSF/geni-portal/pull/1496))
+* Add "Contact Us" page to the portal, and add link to it in help dropdown  (PR [#1495](https://github.com/GENI-NSF/geni-portal/pull/1495))
+* Make projects.php redirect to projects tab on the dashboard. (PR [#1494](https://github.com/GENI-NSF/geni-portal/pull/1494))
+* Handle text overflow on project and slice cards on dashboard. (PR [#1493](https://github.com/GENI-NSF/geni-portal/pull/1493))
+* Fix erroneous popup warning when "Renew slice" clicked. (PR [#1490](https://github.com/GENI-NSF/geni-portal/pull/1490))
+* Add link to 'Other Tools' wiki page listing omni, etc. to header (PR [#1489](https://github.com/GENI-NSF/geni-portal/pull/1489))
+* Make maps on the portal Google maps (PR [#1428](https://github.com/GENI-NSF/geni-portal/pull/1428))
+* Migrate some db schemas to geni-ch (PR [#1411](https://github.com/GENI-NSF/geni-portal/pull/1411))
+
+# Release 3.0
+
+## Issues Closed
+
+* 'New Slice' from project card gives page where you cannot create a slice ([#1478](https://github.com/GENI-NSF/geni-portal/issues/1478))
+* Renew resources (7 days) on slice with faraway expiration causes an error.  ([#1473](https://github.com/GENI-NSF/geni-portal/issues/1473))
+* Renew resources (X days) in the slice dropdown has the wrong value for X. ([#1471](https://github.com/GENI-NSF/geni-portal/issues/1471))
+* Undefined variable log_msg in db_utils.php on line 103 ([#1467](https://github.com/GENI-NSF/geni-portal/issues/1467))
+* wimax-enable.php fails with too many redirects for users with no projects ([#1464](https://github.com/GENI-NSF/geni-portal/issues/1464))
+* account changes always look like lead requests ([#1463](https://github.com/GENI-NSF/geni-portal/issues/1463))
+* Link to SAVI testbed ([#1455](https://github.com/GENI-NSF/geni-portal/issues/1455))
+* Remove Flack from Home and Slice Pages ([#1451](https://github.com/GENI-NSF/geni-portal/issues/1451))
+* Manage Resources button on slice page doesn't work ([#1448](https://github.com/GENI-NSF/geni-portal/issues/1448))
+* Add a Create Image button on the Jacks app ([#1389](https://github.com/GENI-NSF/geni-portal/issues/1389))
+* Account changes posts telephone changes when it is unchanged ([#1339](https://github.com/GENI-NSF/geni-portal/issues/1339))
+* Move or duplicate Wimax button ([#1262](https://github.com/GENI-NSF/geni-portal/issues/1262))
+* Redesign the home page ([#1146](https://github.com/GENI-NSF/geni-portal/issues/1146))
+* Add Renew button to the per slice row ([#711](https://github.com/GENI-NSF/geni-portal/issues/711))
+* note on home.php and slice.php if there is imminent expiration of a slice (and slivers where possible) ([#613](https://github.com/GENI-NSF/geni-portal/issues/613))
+* Remove "account" and "identity" tables ([#299](https://github.com/GENI-NSF/geni-portal/issues/299))
+
+## Pull Requests Merged
+
+* Fix issue where create slice button was disabled when project_id was given in URL params (PR [#1480](https://github.com/GENI-NSF/geni-portal/pull/1480))
+* Fix issue where renew button in slice dropdown would try and shorten slice lifetime (PR [#1476](https://github.com/GENI-NSF/geni-portal/pull/1476))
+* Bump major version (PR [#1474](https://github.com/GENI-NSF/geni-portal/pull/1474))
+* Don't store all profile changes as lead requests (PR [#1466](https://github.com/GENI-NSF/geni-portal/pull/1466))
+* Tkt1389 createimage (PR [#1452](https://github.com/GENI-NSF/geni-portal/pull/1452))
+* Restore manage resources functionality (PR [#1450](https://github.com/GENI-NSF/geni-portal/pull/1450))
+* Remove account and identity tables (issue 299) (PR [#1415](https://github.com/GENI-NSF/geni-portal/pull/1415))


### PR DESCRIPTION
Use markdown format in the CHANGES file. Leverage the GitHub API to
automatically generate the CHANGES list, including issues closed and
pull requests merged. Separate CHANGES by major version to keep the
file size manageable.