### PR TITLE
Hotfix 3.4.2

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -25,6 +25,7 @@ pkgsysconfdir = $(sysconfdir)/geni-ch
 dist_bin_SCRIPTS = \
 		geni-manage-maintenance \
 		geni-parse-map-data \
+		geni-sync-wireless \
 		geni-watch-omni
 
 bin_SCRIPTS = \

--- a/bin/geni-sync-wireless
+++ b/bin/geni-sync-wireless
@@ -177,6 +177,31 @@ class WirelessProjectManager:
     # Turn ORBIT name to GENI name (remove geni- prefix)
     def to_geni_name(self, name): return name[5:]
 
+    def insert_wimax_username(self, member_id, member_info):
+        username = member_info['username']
+        name = 'wimax_username'
+        value = self.to_orbit_name(username)
+        self_asserted = False
+        syslog("Setting wimax_username for %s to %s" % (username, value))
+        ins = self.MEMBER_ATTRIBUTE_TABLE.insert().values(
+                member_id=member_id,
+                name=name,
+                value=value,
+                self_asserted=self_asserted)
+        result = self._session.execute(ins)
+        self._session.commit()
+
+    def ensure_wimax_username(self, member_id, member_info):
+        """Ensure that the given member has a wimax_username set
+        in the member attribute table. Add it if they don't.
+        """
+        username = member_info['username']
+        wimax_username = None
+        if 'wimax_username' in member_info:
+            wimax_username = member_info['wimax_username']
+        if not wimax_username:
+            self.insert_wimax_username(member_id, member_info)
+
     # Top level synchronization function
     # Gather GENI clearinghouse sense of projects/members
     #    Possibly limited to specific project or user
@@ -310,6 +335,7 @@ class WirelessProjectManager:
             username = member_info['username']
             if username == self._options.holdingpen_admin: continue
             orbit_username = self.to_orbit_name(username)
+            self.ensure_wimax_username(member_id, member_info)
             if orbit_username not in self._orbit_users:
                 member_pretty_name = self.get_pretty_name(member_info)
                 member_ssh_keys = member_info['ssh_keys']
@@ -575,7 +601,7 @@ class WirelessProjectManager:
                 member_ids))
         query = query.filter(self.MEMBER_ATTRIBUTE_TABLE.c.name.in_(\
                 ["username", 'member_enabled', "first_name", "email_address", 
-                 "last_name", "displayName"]))
+                 "last_name", "displayName", 'wimax_username']))
         
         member_rows = query.all()
         for row in member_rows:

--- a/bin/geni-sync-wireless
+++ b/bin/geni-sync-wireless
@@ -337,15 +337,16 @@ class WirelessProjectManager:
     def ensure_project_members_exist(self): 
         for member_id, member_info in self._geni_members.items():
             username = member_info['username']
-            if username == self._options.holdingpen_admin: continue
+            if username == self._options.holdingpen_admin:
+                continue
+            member_ssh_keys = member_info['ssh_keys']
+            if len(member_ssh_keys) == 0:
+                syslog("Skipping user with no ssh keys: %s" % username)
+                continue
             orbit_username = self.to_orbit_name(username)
             self.ensure_wimax_username(member_id, member_info)
             if orbit_username not in self._orbit_users:
                 member_pretty_name = self.get_pretty_name(member_info)
-                member_ssh_keys = member_info['ssh_keys']
-                if len(member_ssh_keys) == 0:
-                    syslog("Skipping user with no ssh keys: %s" % username)
-                    continue
                 syslog("Creating ORBIT user: %s" % orbit_username)
                 first_name = ""
                 if 'first_name' in member_info: 

--- a/bin/geni-sync-wireless
+++ b/bin/geni-sync-wireless
@@ -240,8 +240,12 @@ class WirelessProjectManager:
         if self._options.verbose:
             syslog("GENI PROJECTS = %s" % self._geni_projects)
             syslog("GENI MEMBERS = %s" % self._geni_members)
-            syslog("ORBIT GROUPS = %s" % self._orbit_groups)
-            syslog("ORBIT USERS = %s" % self._orbit_users)
+            for k,v in self._orbit_groups.iteritems():
+                syslog("ORBIT GROUP %s admin %s" % (k, v['admin']))
+                for u in v['users']:
+                    syslog("ORBIT GROUP %s member %s" % (k, u))
+            for u in self._orbit_users:
+                syslog("ORBIT USER %s" % (u))
 
         # Make sure the holdingpen gorup and admin exist
         self.ensure_holdingpen_group_and_admin()

--- a/bin/portal_utils/orbit_interface.py
+++ b/bin/portal_utils/orbit_interface.py
@@ -203,8 +203,7 @@ class ORBIT_Interface:
     def get_orbit_groups_and_users(self):
         orbit_query_url = "%s/getGroupsAndUsers" % self._base_orbit_url
         orbit_info_raw = self.get_curl_output(orbit_query_url)
-        orbit_groups = self.parse_group_user_info(orbit_info_raw)
-        orbit_users = set()
+        orbit_groups, orbit_users = self.parse_group_user_info(orbit_info_raw)
         for group_name, group_info in orbit_groups.items():
             orbit_group_member_query_url = \
                 "%s/getProjectMembers?groupname=%s" % \
@@ -212,14 +211,13 @@ class ORBIT_Interface:
             orbit_member_info_raw = \
                 self.get_curl_output(orbit_group_member_query_url)
             users = self.parse_group_members(orbit_member_info_raw)
-            for user in users:
-                orbit_users.add(user)
-                group_info['users'] = users
-        return orbit_groups, list(orbit_users)
+            group_info['users'] = users
+        return orbit_groups, orbit_users
 
     # Parse results from getGroupsAndUsers call
     def parse_group_user_info(self, orbit_info_raw):
         groups = {}
+        users = []
         orbit_info = xml.dom.minidom.parseString(orbit_info_raw)
         group_nodes = orbit_info.getElementsByTagName('Group')
         user_nodes = orbit_info.getElementsByTagName('User')
@@ -229,12 +227,8 @@ class ORBIT_Interface:
             groups[group_name] = {'admin' : group_admin, 'users' : []}
         for user_node in user_nodes:
             user_name = user_node.getAttribute('username')
-            group_name = user_node.getAttribute('groupname')
-            if group_name not in groups:
-                syslog("Group %s for user %s not defined" % \
-                    (group_name, user_name))
-            group = groups[group_name]['users'].append(user_name)
-        return groups
+            users.append(user_name)
+        return groups, users
 
     # Parse results from getProjectMembers call
     def parse_group_members(self, orbit_info_raw):

--- a/bin/portal_utils/orbit_interface.py
+++ b/bin/portal_utils/orbit_interface.py
@@ -266,7 +266,7 @@ class ORBIT_Interface:
                                              stderr=err_file)
             os.unlink(err_filename)
         except subprocess.CalledProcessError as e:
-            error_text = open(err_filemame, 'r'). read()
+            error_text = open(err_filename, 'r'). read()
             syslog("Error invoking curl LDIF saveUser command: %s: Error %s Msg %s" \
                 (save_user_url, e.returncode, error_text))
             os.unlink(err_fileame)

--- a/lib/php/user.php
+++ b/lib/php/user.php
@@ -445,15 +445,12 @@ function geni_load_user_by_eppn($eppn, $sfcred)
 {
   $ma_url = get_first_service_of_type(SR_SERVICE_TYPE::MEMBER_AUTHORITY);
   //  $attrs = array('eppn' => $eppn);
-  geni_syslog(GENI_SYSLOG_PREFIX::PORTAL, "Looking up EPPN " . $eppn);
   $signer = Portal::getInstance($sfcred);
   $member = ma_lookup_member_by_eppn($ma_url, $signer, $eppn);
   //error_log("MEMBER = " . print_r($member, True));
   if (is_null($member) || !isset($member->certificate)) {
     // New identity, go to activation page
     relative_redirect("kmactivate.php");
-  } else {
-    geni_syslog(GENI_SYSLOG_PREFIX::PORTAL, "Found member for EPPN " . $eppn);
   }
   $user = new GeniUser();
   $user->init_from_member($member);


### PR DESCRIPTION
* Restore `wimax_username` in wireless sync. It got lost with the shift to the new API and new sync script.
* Use the list of users provided by orbit so that orphaned users will be recreated
* Install `geni-sync-wireless` on `make install`
* Remove overly verbose syslog messages about EPPN lookups. They obscure the important messages.

Fixes #1595
