### PR TITLE
Fix referer redirect when portal is not authorized

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 = GENI Portal Release Notes =
 
 == 3.5 ==
+ * Fix referer redirect when portal is not authorized (#1604)
 
 == 3.4 ==
  * Improve error handling for failed slice searches on admin page (#1417)

--- a/lib/php/user.php
+++ b/lib/php/user.php
@@ -448,13 +448,18 @@ function geni_load_user_by_eppn($eppn, $sfcred)
   $signer = Portal::getInstance($sfcred);
   $member = ma_lookup_member_by_eppn($ma_url, $signer, $eppn);
   //error_log("MEMBER = " . print_r($member, True));
-  if (is_null($member) || !isset($member->certificate)) {
+  if (is_null($member)) {
     // New identity, go to activation page
     relative_redirect("kmactivate.php");
   }
   $user = new GeniUser();
   $user->init_from_member($member);
   $user->sfcred = $sfcred;
+  if (! $sfcred && ! $user->portalIsAuthorized()) {
+    // Portal is not authorized (no inside certificate)
+    // and no speaks-for cred has been supplied.
+    relative_redirect("kmhome.php");
+  }
   return $user;
 }
 


### PR DESCRIPTION
Redirect one way of the user is new and a different way if the portal
is not authorized. This avoids a referer redirect which prevented
user's from ever authorizing the portal again.

Fixes #1604