### PR TITLE
Add an aggregate status page

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@
 = GENI Portal Release Notes =
 
 == 3.5 ==
+ * Fix a renew bug on Firefox (#1590)
+ * Provide aggregate status to Jacks (#1600)
+ * Add an aggregate status page (#1601)
  * Fix referer redirect when portal is not authorized (#1604)
 
 == 3.4 ==

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -6,6 +6,7 @@
 svcdatadir = $(pkgdatadir)/portal
 gcfsrcdir = $(svcdatadir)/gcf/src
 gcfsrcgenidir = $(gcfsrcdir)/geni
+pkgsysconfdir = $(sysconfdir)/geni-ch
 
 # This is silly -- easier to rename the file in git
 # TODO: rename the file in git and remove this extraneous target
@@ -27,6 +28,31 @@ svcwebmapolthemeimgdir = /var/www/common/map/OpenLayers-2.13/theme/default/img
 svcwebtopdir = /var/www
 svcwebpolicydir = /var/www/policy
 
+edit = sed \
+	-e 's|@bindir[@]|$(bindir)|g' \
+	-e 's|@pkgdatadir[@]|$(pkgdatadir)|g' \
+	-e 's|@pkgsysconfdir[@]|$(pkgsysconfdir)|g' \
+	-e 's|@prefix[@]|$(prefix)|g'
+
+TEMPLATES = \
+	www/portal/am-status.php
+
+TEMPLATES.IN = $(TEMPLATES:%=%.in)
+
+$(TEMPLATES): Makefile
+	rm -f $@ $@.tmp
+	srcdir=''; \
+		test -f ./$@.in || srcdir=$(srcdir)/; \
+		$(edit) $${srcdir}$@.in >$@.tmp
+	chmod a-w $@.tmp
+	mv $@.tmp $@
+
+%: $(srcdir)/%.in
+
+# Distribute but do not install
+EXTRA_DIST = $(TEMPLATES.IN)
+
+CLEANFILES = $(TEMPLATES)
 
 nobase_dist_svcdata_DATA = \
 	apache2-http.conf \
@@ -65,6 +91,7 @@ dist_svcweb_DATA = \
 	www/portal/amdetails.php \
 	www/portal/amstatus.js \
 	www/portal/amstatus.php \
+	www/portal/am-status.php \
 	www/portal/ask-for-project.php \
 	www/portal/cancel-join-project.php \
 	www/portal/cards.js \

--- a/portal/www/portal/am-status.php.in
+++ b/portal/www/portal/am-status.php.in
@@ -131,6 +131,7 @@ show_header('GENI Portal: Aggregate Status');
 
 
 <h1>Aggregate Status</h1>
+<p>Current aggregate responsiveness to GENI AM API calls</p>
 <div class='tablecontainer'>
 <table id='aggtable'>
 <thead>
@@ -144,6 +145,16 @@ foreach ($table_rows as $row) {
 }
 ?>
 </tbody></table></div>
+
+<section>
+<h3>Legend</h3>
+<p>
+Up: Responding to GENI AM API calls
+</p>
+<p>
+Down: Failed to respond to GENI AM API calls when last checked
+</p>
+</section>
 
 <script type="text/javascript">
 $(document).ready(function () {

--- a/portal/www/portal/am-status.php.in
+++ b/portal/www/portal/am-status.php.in
@@ -1,0 +1,124 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2015 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+
+require_once("user.php");
+require_once("header.php");
+require_once("sr_client.php");
+require_once("sr_constants.php");
+
+$AM_STATUS_FILE = "@pkgsysconfdir@/am-status.json";
+
+/**
+ * Load a mapping from URN to status. This is a JSON file,
+ * so load it and parse it as JSON.
+ *
+ * Return an array whose keys are aggregate URNs and whose
+ * values are states like "up" or "down".
+ */
+function load_am_status($fname)
+{
+  $str_data = file_get_contents($fname);
+  $data = json_decode($str_data, true);
+  return $data;
+}
+
+/**
+ * Convert a status string into an icon.
+ */
+function status_to_icon($status)
+{
+  if ($status == "up") {
+    $color = "#339933";
+    $icon = "check_circle";
+  } else if ($status == "down") {
+    $color = "#EE583A";
+    $icon = "report";
+  } else {
+    $color =  "#FBC02D";
+    $icon = "warning";
+  }
+  $result = "<i class='material-icons' style='color:$color;'>$icon</i>";
+  return $result;
+}
+
+function make_agg_row($agg, $status_data)
+{
+  $name = $agg[SR_TABLE_FIELDNAME::SERVICE_NAME];
+  $urn = $agg[SR_TABLE_FIELDNAME::SERVICE_URN];
+  $status = "up";
+  if (array_key_exists($urn, $status_data)) {
+    $status = $status_data[$urn];
+  }
+  $icon = status_to_icon($status);
+
+  $row = '<tr>';
+  $row .= '<td>' . $name . '</td>';
+  $row .= '<td>' . $icon . '</td>';
+  $row .= '<td>' . $status . '</td>';
+  $row .= '</tr>';
+  return $row;
+}
+
+/**
+ * Compare two aggregates by their names.
+ * Comparison function for use with usort()
+ */
+function cmp_aggs($a, $b) {
+  $aname = strtolower($a[SR_TABLE_FIELDNAME::SERVICE_NAME]);
+  $bname = strtolower($b[SR_TABLE_FIELDNAME::SERVICE_NAME]);
+  return strcmp($aname, $bname);
+}
+
+$user = geni_loadUser();
+if (!isset($user) || is_null($user) || ! $user->isActive()) {
+  relative_redirect('home.php');
+}
+
+$aggs = get_services_of_type(SR_SERVICE_TYPE::AGGREGATE_MANAGER);
+usort($aggs, "cmp_aggs");
+
+$status_data = load_am_status($AM_STATUS_FILE);
+
+$table_rows = array();
+foreach ($aggs as $am) {
+  $table_rows[] = make_agg_row($am, $status_data);
+}
+
+show_header('GENI Portal: Aggregate Status');
+?>
+
+
+<h1>Aggregate Status</h1>
+<table>
+<?php
+foreach ($table_rows as $row) {
+  print($row);
+  print("\n");
+}
+?>
+</table>
+
+<?php
+include("footer.php");
+?>

--- a/portal/www/portal/am-status.php.in
+++ b/portal/www/portal/am-status.php.in
@@ -148,12 +148,12 @@ foreach ($table_rows as $row) {
 
 <section>
 <h3>Legend</h3>
-<p>
-Up: Responding to GENI AM API calls
-</p>
-<p>
-Down: Failed to respond to GENI AM API calls when last checked
-</p>
+<dl>
+  <dt>Up</dt>
+  <dd>Responding to GENI AM API calls</dd>
+  <dt>Down</dt>
+  <dd>Failed to respond to GENI AM API calls when last checked</dd>
+</dl>
 </section>
 
 <script type="text/javascript">

--- a/portal/www/portal/am-status.php.in
+++ b/portal/www/portal/am-status.php.in
@@ -73,9 +73,8 @@ function make_agg_row($agg, $status_data)
   $icon = status_to_icon($status);
 
   $row = '<tr>';
-  $row .= '<td>' . $name . '</td>';
-  $row .= '<td>' . $icon . '</td>';
-  $row .= '<td>' . $status . '</td>';
+  $row .= "<td>$name</td>";
+  $row .= "<td>$icon &nbsp; &nbsp; $status</td>";
   $row .= '</tr>';
   return $row;
 }
@@ -110,14 +109,25 @@ show_header('GENI Portal: Aggregate Status');
 
 
 <h1>Aggregate Status</h1>
-<table>
+<div class='tablecontainer'>
+<table id='aggtable'>
+<thead>
+<tr><th>Name &#x2191;&#x2193;</th><th>Status &#x2191;&#x2193;</th></tr>
+</thead>
+<tbody>
 <?php
 foreach ($table_rows as $row) {
   print($row);
   print("\n");
 }
 ?>
-</table>
+</tbody></table></div>
+
+<script type="text/javascript">
+$(document).ready(function () {
+    $('#aggtable').DataTable({paging: false});
+  });
+</script>
 
 <?php
 include("footer.php");

--- a/portal/www/portal/am-status.php.in
+++ b/portal/www/portal/am-status.php.in
@@ -44,19 +44,40 @@ function load_am_status($fname)
 }
 
 /**
+ * Convert a status string into a string for display on the UI.
+ */
+function status_to_display($status)
+{
+  switch($status) {
+    case "up":
+      $result = "Up";
+      break;
+    case "down":
+      $result = "Down";
+      break;
+    default:
+      $result = "Uknown";
+  }
+  return $result;
+}
+
+/**
  * Convert a status string into an icon.
  */
 function status_to_icon($status)
 {
-  if ($status == "up") {
-    $color = "#339933";
-    $icon = "check_circle";
-  } else if ($status == "down") {
-    $color = "#EE583A";
-    $icon = "report";
-  } else {
-    $color =  "#FBC02D";
-    $icon = "warning";
+  switch($status) {
+    case "up":
+      $color = "#339933";
+      $icon = "check_circle";
+      break;
+    case "down":
+      $color = "#EE583A";
+      $icon = "report";
+      break;
+    default:
+      $color =  "#FBC02D";
+      $icon = "warning";
   }
   $result = "<i class='material-icons' style='color:$color;'>$icon</i>";
   return $result;
@@ -71,10 +92,11 @@ function make_agg_row($agg, $status_data)
     $status = $status_data[$urn];
   }
   $icon = status_to_icon($status);
+  $pretty_status = status_to_display($status);
 
   $row = '<tr>';
   $row .= "<td>$name</td>";
-  $row .= "<td>$icon &nbsp; &nbsp; $status</td>";
+  $row .= "<td>$icon &nbsp; &nbsp; $pretty_status</td>";
   $row .= '</tr>';
   return $row;
 }

--- a/portal/www/portal/slice-add-resources-jacks.php
+++ b/portal/www/portal/slice-add-resources-jacks.php
@@ -226,6 +226,11 @@ print "<button onClick=\"history.back(-1)\">Cancel</button>\n";
 print '</p>';
 $slice_nojacks_url = "slice-add-resources.php?slice_id=$slice_id";
 print "<p><b>Note:</b> To reserve FOAM or other non-compute resources, use the <button onClick=\"window.location='$slice_nojacks_url'\"><b>Non Jacks Add Resources</b></button> page.</p>";
+?>
+<p>
+  You can view the <a href="am-status.php">current status of aggregates</a>.
+</p>
+<?php
 
 // END add resources tab
 echo "</div>";

--- a/portal/www/portal/slice-add-resources-jacks.php
+++ b/portal/www/portal/slice-add-resources-jacks.php
@@ -209,6 +209,7 @@ print '<input type="hidden" name="stitch_rspec" id="stitch_rspec" value="0"/>';
 print '</form>';
 
 ?>
+<p><a href="am-status.php">View current aggregate status</a></p>
 <?php
 
 print "<p><b>Note:</b> Use the 'Manage RSpecs' tab to add a permanent RSpec.</p>";
@@ -226,11 +227,6 @@ print "<button onClick=\"history.back(-1)\">Cancel</button>\n";
 print '</p>';
 $slice_nojacks_url = "slice-add-resources.php?slice_id=$slice_id";
 print "<p><b>Note:</b> To reserve FOAM or other non-compute resources, use the <button onClick=\"window.location='$slice_nojacks_url'\"><b>Non Jacks Add Resources</b></button> page.</p>";
-?>
-<p>
-  You can view the <a href="am-status.php">current status of aggregates</a>.
-</p>
-<?php
 
 // END add resources tab
 echo "</div>";

--- a/portal/www/portal/slice-add-resources.php
+++ b/portal/www/portal/slice-add-resources.php
@@ -265,6 +265,9 @@ print '<input type="hidden" name="bound_rspec" id="bound_rspec" value="0"/>';
 print '<input type="hidden" name="stitch_rspec" id="stitch_rspec" value="0"/>';
 print '</form>';
 
+?>
+<p><a href="am-status.php">View current aggregate status</a></p>
+<?php
 print "<p><b>Note:</b> Use the 'Manage RSpecs' tab to add a permanent RSpec; use 'Choose File' to temporarily upload an RSpec for this reservation only.</p>";
 
 print ("<p><button id='rspec_submit_button' disabled='disabled' onClick=\"");
@@ -275,11 +278,6 @@ print '</p>';
 
 $slice_jacks_url = "slice-add-resources-jacks.php?slice_id=$slice_id";
 print "<p><b>Note:</b> For a graphical reservation tool, use the <button onClick=\"window.location='$slice_jacks_url'\"><b>Jacks Add Resources</b></button> page.</p>";
-?>
-<p>
-  You can view the <a href="am-status.php">current status of aggregates</a>.
-</p>
-<?php
 // END add resources tab
 echo "</div>";
 

--- a/portal/www/portal/slice-add-resources.php
+++ b/portal/www/portal/slice-add-resources.php
@@ -275,7 +275,11 @@ print '</p>';
 
 $slice_jacks_url = "slice-add-resources-jacks.php?slice_id=$slice_id";
 print "<p><b>Note:</b> For a graphical reservation tool, use the <button onClick=\"window.location='$slice_jacks_url'\"><b>Jacks Add Resources</b></button> page.</p>";
-
+?>
+<p>
+  You can view the <a href="am-status.php">current status of aggregates</a>.
+</p>
+<?php
 // END add resources tab
 echo "</div>";
 


### PR DESCRIPTION
Use the aggregate status information to drive a simple page displaying aggregates status. 

Fixes #1601 