### PR TITLE
Remove debug printouts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,9 +6,11 @@
 
 == 3.5 ==
  * Fix a renew bug on Firefox (#1590)
+ * Remove debug printouts (#1598)
  * Provide aggregate status to Jacks (#1600)
  * Add an aggregate status page (#1601)
  * Fix referer redirect when portal is not authorized (#1604)
+ * For details see https://github.com/GENI-NSF/geni-portal/milestones/3.5
 
 == 3.4 ==
  * Improve error handling for failed slice searches on admin page (#1417)

--- a/portal/www/portal/image_operations.php
+++ b/portal/www/portal/image_operations.php
@@ -131,16 +131,11 @@ function perform_list_operation()
 					 '--project', $_GET['project_name'],
 					 '-u', $_GET['sliver_id']));
     $response = $response[1];
-    error_log("RESP = " . print_r($response, true));
   } else if ($operation == 'deleteimage') {
-    error_log("HERE");
     $urn = $_GET['image_urn'];
-    error_log("URN = " . $urn);
-    error_log("URN = " . print_r($urn, true));
     $args = array('deleteimage', $urn);
     $response = invoke_omni_function($am_url, $user, $args);
     $response = $response[1][$am_url];
-    error_log("RESP = " . print_r($response, true));
   }
 
   $code = $response['code']['geni_code'];
@@ -152,8 +147,6 @@ function perform_list_operation()
 }
 
 $result = perform_list_operation();
-
-error_log("RESULT = " . print_r($result, true));
 
 header("Cache-Control: public");
 header("Content-Type: application/json");


### PR DESCRIPTION
Remove a series of debug printouts from image_operations.

Fixes #1598 