### PR TITLE
Auto replace version in lib/php/settings.php

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,5 +1,28 @@
 svcdatadir = $(pkgdatadir)/lib
 
+edit = sed \
+	-e 's|@VERSION[@]|$(VERSION)|g'
+
+TEMPLATES = \
+	php/settings.php
+
+TEMPLATES.IN = $(TEMPLATES:%=%.in)
+
+$(TEMPLATES): Makefile
+	rm -f $@ $@.tmp
+	srcdir=''; \
+		test -f ./$@.in || srcdir=$(srcdir)/; \
+		$(edit) $${srcdir}$@.in >$@.tmp
+	chmod a-w $@.tmp
+	mv $@.tmp $@
+
+%: $(srcdir)/%.in
+
+# Distribute but do not install
+EXTRA_DIST = $(TEMPLATES.IN)
+
+CLEANFILES = $(TEMPLATES)
+
 nobase_dist_svcdata_DATA = \
 	php/abac.php \
 	php/am_client.php \
@@ -19,7 +42,7 @@ nobase_dist_svcdata_DATA = \
 	php/header.php \
 	php/home-active.php \
 	php/irods_utils.php \
-        php/jacks-app.php \
+	php/jacks-app.php \
 	php/jacks-editor-app.php \
 	php/json_util.php \
 	php/logging_client.php \

--- a/lib/php/settings.php.in
+++ b/lib/php/settings.php.in
@@ -47,7 +47,7 @@ $portal_private_key_file = '/usr/share/geni-ch/portal/portal-key.pem';
 $portal_max_slice_renewal_days = 185;
 
 // Portal version
-$portal_version = "3.5";
+$portal_version = "@VERSION@";
 
 // URL to the Flack loader. Used in flack.php
 $flack_url = "https://www.emulab.net/protogeni/flack-stable/loader.js";
@@ -58,7 +58,7 @@ $flack_url = "https://www.emulab.net/protogeni/flack-stable/loader.js";
 $jacks_stable_url = "https://www.emulab.net/protogeni/jacks-stable/js/jacks";
 //$jacks_stable_url = "https://portal.geni.net/jacks-stable/js/jacks";
 
-// Sources for external libraries the portal uses 
+// Sources for external libraries the portal uses
 
 // Version 2.1.4 most recent as of 6/2015
 $portal_jquery_url = 'https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js';


### PR DESCRIPTION
Use Automake to replace the version number in settings.php instead of
manually editing the file with each version.