### PR TITLE
Check errors when loading am status data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # [Release 3.6](https://github.com/GENI-NSF/geni-portal/milestones/3.6)
 
+* Check errors when loading am status data
+  ([#1614](https://github.com/GENI-NSF/geni-portal/issues/1614))
 
 # [Release 3.5](https://github.com/GENI-NSF/geni-portal/milestones/3.5)
 

--- a/portal/www/amstatus.php.in
+++ b/portal/www/amstatus.php.in
@@ -39,7 +39,18 @@ $AM_STATUS_FILE = "@pkgsysconfdir@/am-status.json";
 function load_am_status($fname)
 {
   $str_data = file_get_contents($fname);
-  $data = json_decode($str_data, true);
+  if ($str_data === FALSE) {
+    # Unable to read am status data file. The error has already been
+    # logged by PHP. Return an empty array.
+    $data = array();
+  } else {
+    $data = json_decode($str_data, true);
+    if (is_null($data)) {
+      # json_decode has failed, return empty array
+      error_log("Unable to JSON decode data in $fname");
+      $data = array();
+    }
+  }
   return $data;
 }
 


### PR DESCRIPTION
Avoid unsightly log messages by more carefully checking for error
conditions. Always return an array from the data loading function.