### PR TITLE
Fix a SQL syntax error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 * Check errors when loading am status data
   ([#1614](https://github.com/GENI-NSF/geni-portal/issues/1614))
+* Fix a SQL syntax error in the portal schema
+  ([#1615](https://github.com/GENI-NSF/geni-portal/issues/1615))
 
 # [Release 3.5](https://github.com/GENI-NSF/geni-portal/milestones/3.5)
 

--- a/portal/db/postgresql/schema.sql
+++ b/portal/db/postgresql/schema.sql
@@ -229,7 +229,7 @@ DROP TABLE IF EXISTS last_seen;
 CREATE TABLE last_seen (
   id SERIAL,
   member_id UUID NOT NULL,
-  ts timestamp not null default NOW() AT TIME ZONE 'UTC',
+  ts timestamp not null default (NOW() AT TIME ZONE 'UTC'),
   request_uri VARCHAR,
   PRIMARY KEY (id)
 );
@@ -271,7 +271,7 @@ CREATE TABLE lead_request (
   requester_urn   VARCHAR NOT NULL,
   requester_uuid  UUID NOT NULL,
   requester_eppn  VARCHAR NOT NULL,
-  request_ts timestamp NOT NULL default NOW() AT TIME ZONE 'UTC',
+  request_ts timestamp NOT NULL default (NOW() AT TIME ZONE 'UTC'),
   approver VARCHAR default '',
   notes VARCHAR default '',
   reason VARCHAR default '',


### PR DESCRIPTION
Add parentheses around "now() at time zone 'UTC'" in a column
definition requires to avoid a SQL syntax error.