### PR TITLE
Fix a SQL syntax error

### DIFF
--- a/kmtool/db/postgresql/schema.sql
+++ b/kmtool/db/postgresql/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE km_asserted_attribute (
   name VARCHAR NOT NULL,
   value VARCHAR NOT NULL,
   asserter_id UUID,
-  created timestamp DEFAULT NOW() AT TIME ZONE 'UTC'
+  created timestamp DEFAULT (NOW() AT TIME ZONE 'UTC')
 );
 
 CREATE INDEX km_asserted_attribute_eppn ON km_asserted_attribute (eppn);


### PR DESCRIPTION
Add parentheses around "now() at time zone 'UTC'" in a column
definition requires to avoid a SQL syntax error.