### PR TITLE
Reduce database queries

### DIFF
--- a/lib/php/tools-admin.php
+++ b/lib/php/tools-admin.php
@@ -165,7 +165,9 @@ foreach ($lead_requests as $lead_request) {
   $requester_uuids[] = $lead_request['requester_uuid'];
 }
 
-$requester_details = lookup_member_details($ma_url, $user, $requester_uuids); 
+if ($requester_uuids) {
+  $requester_details = lookup_member_details($ma_url, $user, $requester_uuids);
+}
 
 print "<table><tr><th>Name</th><th>Link</th><th>Requested At</th><th>Email</th><th>Admin Notes</th><th>Actions</th></tr>";
 

--- a/lib/php/tools-user.php
+++ b/lib/php/tools-user.php
@@ -574,8 +574,8 @@ $preference_descriptions = array(
 foreach($possible_prefs as $pref_name => $pref_values) {
   print $preference_descriptions[$pref_name];
   print "<select id='default_{$pref_name}' class='preferenceselect'>";
+  $user_value = get_preference($user->urn(), $pref_name);
   foreach ($pref_values as $pref_value) {
-    $user_value = get_preference($user->urn(), $pref_name);
     $selected = $pref_value == $user_value ? "selected" : "";
     print "<option value='$pref_value' $selected>$pref_value</option>";
   }

--- a/lib/php/user-preferences.php
+++ b/lib/php/user-preferences.php
@@ -22,17 +22,6 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 
-require_once("user.php");
-require_once("db_utils.php");
-require_once("ma_constants.php");
-require_once("ma_client.php");
-require_once("util.php");
-
-$user = geni_loadUser();
-if (!isset($user) || is_null($user) || ! $user->isActive()) {
-  exit();
-}
-
 // Map of preference names to choices for that pref. The first element in the array
 // of choices is the default value.
 $possible_prefs = array(
@@ -48,7 +37,6 @@ function get_preference($user_urn, $preference) {
     $sql = "SELECT * from user_preferences "
     . "where user_urn = " . $conn->quote($user_urn, 'text')
     . "and preference_name = " . $conn->quote($preference, 'text');
-    $db_res = db_fetch_row($sql);
     $db_response = db_fetch_row($sql, "Get user preference");
 
     $db_error = $db_response[RESPONSE_ARGUMENT::OUTPUT];


### PR DESCRIPTION
1. Do not query for user details when there are no lead requests
2. Request each user preference once when displaying the preferences page
3. Remove an extra load of user information from any page the includes preferences
4. Remove a duplicate database query when fetching preferences
