### PR TITLE
Tkt1639 getprojects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
 # GENI Portal Release Notes
 
 # [Release 3.8](https://github.com/GENI-NSF/geni-portal/milestones/3.8)
- * Join this project must correctly check return indicating
-   an existing request to join this project. 
+* Join this project must correctly check return indicating
+  an existing request to join this project. 
   ([#1637](https://github.com/GENI-NSF/geni-portal/issues/1637))
+* `get_project` uses wrong variable name for result. `lookup_project_details`
+  should bail when given empty list of projet UIDs.
+  ([#1639](https://github.com/GENI-NSF/geni-portal/issues/1639))
 
 # [Release 3.7](https://github.com/GENI-NSF/geni-portal/milestones/3.7)
 

--- a/lib/php/pa_client.php
+++ b/lib/php/pa_client.php
@@ -474,7 +474,7 @@ function lookup_project_details($sa_url, $signer, $project_uuids)
 
   $client = XMLRPCClient::get_client($sa_url, $signer);
   if (! isset($project_uuids) || is_null($project_uuids) || count($project_uuids) == 0) {
-    error_log("Asked to lookup detils on no projects");
+    error_log("Asked to lookup details on no project uuids");
     return array();
   }
   $options = array('match' => array('PROJECT_UID' => array_values($project_uuids)));

--- a/lib/php/pa_client.php
+++ b/lib/php/pa_client.php
@@ -92,7 +92,7 @@ function get_projects($sa_url, $signer)
 		   'filter'=>array('PROJECT_UID'));
   $options = array_merge($options, $client->options());
   $res = $client->lookup_projects($client->creds(), $options);
-  return array_map(function($x) { return $x['PROJECT_UID']; }, $slices);
+  return array_map(function($x) { return $x['PROJECT_UID']; }, $res);
 }
 
 // return list of project ids
@@ -103,7 +103,7 @@ function get_projects_by_lead($sa_url, $signer, $lead_id)
 		   'filter'=>array('PROJECT_UID'));
   $options = array_merge($options, $client->options());
   $res = $client->lookup_projects($client->creds(), $options);
-  return array_map(function($x) { return $x['PROJECT_UID']; }, $slices);
+  return array_map(function($x) { return $x['PROJECT_UID']; }, $res);
 }
 
 $PACHAPI2PORTAL = array('PROJECT_UID'=>PA_PROJECT_TABLE_FIELDNAME::PROJECT_ID,
@@ -473,6 +473,10 @@ function lookup_project_details($sa_url, $signer, $project_uuids)
   //  error_log("PIDS = " . print_r($project_uuids, true));
 
   $client = XMLRPCClient::get_client($sa_url, $signer);
+  if (! isset($project_uuids) || is_null($project_uuids) || count($project_uuids) == 0) {
+    error_log("Asked to lookup detils on no projects");
+    return array();
+  }
   $options = array('match' => array('PROJECT_UID' => array_values($project_uuids)));
   $options = array_merge($options, $client->options());
   $results = $client->lookup_projects($client->creds(), $options);


### PR DESCRIPTION
fix `get_projects` to use `$res` not $slices`
fix `lookup_project_details` to bail if given empty list of project uuids.