### PR TITLE
Tkt1643 import lead_request and tkt1644

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@
   ([#1639](https://github.com/GENI-NSF/geni-portal/issues/1639))
 * Support properly importing the `lead_request` table into a new database.
   ([#1643](https://github.com/GENI-NSF/geni-portal/issues/1643))
+* Skip re-generating user certs on DB import by default.
+  Use `--regen_certs` for old behavior.
+  ([#1644](https://github.com/GENI-NSF/geni-portal/issues/1644))
 
 # [Release 3.7](https://github.com/GENI-NSF/geni-portal/milestones/3.7)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 * `get_project` uses wrong variable name for result. `lookup_project_details`
   should bail when given empty list of projet UIDs.
   ([#1639](https://github.com/GENI-NSF/geni-portal/issues/1639))
+* Support properly importing the `lead_request` table into a new database.
+  ([#1643](https://github.com/GENI-NSF/geni-portal/issues/1643))
 
 # [Release 3.7](https://github.com/GENI-NSF/geni-portal/milestones/3.7)
 

--- a/etc/member-id-columns.dat
+++ b/etc/member-id-columns.dat
@@ -3,6 +3,7 @@ cs_assertion, principal
 cs_policy, signer
 km_asserted_attribute, asserter_id
 logging_entry, user_id
+lead_request, requester_uuid
 ma_member, member_id
 ma_member_attribute, member_id
 ma_member_privilege, member_id


### PR DESCRIPTION
Fixes for issue #1643 and issue #1644.

Include the `lead_request `requester_uuid` in the columns that are a member_id that must be translated for the import.

Change `import_database` so that by default it does not regenerate user certs, but instead expires them all. The inside cert will be auto renewed when the user logs in next (if ever), and the outside cert must be manually regenerated via the portal by the user. Use `--regen_certs` for the old behavior.
