### PR TITLE
Restrict project names to match clearinghouse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 
 ## Changes
 
-* None
-
+* Update project name constraints to match clearinghouse
+  ([#1689](https://github.com/GENI-NSF/geni-portal/issues/1689))
 
 # [Release 3.11](https://github.com/GENI-NSF/geni-portal/milestones/3.11)
 

--- a/lib/php/pa_constants.php
+++ b/lib/php/pa_constants.php
@@ -112,24 +112,13 @@ class PA_PROJECT_MEMBER_INVITATION_TABLE_FIELDNAME {
 // How long to project invitaations have before they expire?
 $project_default_invitation_expiration_hours = 72;
 
-// Per the AM API V3:
-// We want the project name to go without change into the authority part of the URN
-// so do not use characters that get translated between URN and publicid. So:
-// not empty
-// no whitespace
-// no / : + ; ' ? # %
-// no leading/trailing whitespace
-// collapse consecutive whitespace
-// Additionally, ProtoGENI has a 32character sub-authority limit. So
-// limit project names to 32 characters.
-// We should also be excluding control characters.
-// Technically we could then allow all kinds of unicode
-// characters. But is that really necessary? For now, restrict project
-// names pretty heavily
+// The regex in this function matches the clearinghouse. Do not
+// change it on its own. Its purpose is to prevent an invalid name
+// from going to the clearinghouse and to give
+// users a better UI experience when they choose a bad name.
 function is_valid_project_name($project_name)
 {
-  //  $pattern = '/^[^\/\:\+\;\'\?\#\% ]+$/';
-  $pattern = '/^[a-zA-Z0-9][a-zA-Z0-9-_]{0,31}$/';
+  $pattern = '/^[a-zA-Z][a-zA-Z0-9-_]{1,31}$/';
   return preg_match($pattern, $project_name);
 }
 

--- a/portal/www/portal/do-edit-project.php
+++ b/portal/www/portal/do-edit-project.php
@@ -99,7 +99,7 @@ if ($isnew) {
     relative_redirect('error-text.php?error=' . urlencode("Project Name '$name' is too long - use at most 32 characters."));
   } else if (! is_valid_project_name($name)) {
     error_log("do-edit-project: project name '$name' invalid");
-    relative_redirect('error-text.php?error=' . urlencode("Project Name '$name' is invalid: Use at most 32 alphanumeric characters or hyphen or underscore. No leading hyphen or underscore. "));
+    relative_redirect('error-text.php?error=' . urlencode("Project Name '$name' is invalid: Use at least 2 and most 32 alphanumeric characters or hyphen or underscore. No leading number or hyphen or underscore. "));
   }
   // Re-check authorization?
   // Auto?

--- a/portal/www/portal/edit-project.php
+++ b/portal/www/portal/edit-project.php
@@ -133,7 +133,7 @@ $submit_label = $isnew ? "Create Project" : "Update";
 
 </table>
 <?php
-echo '<p><b>Note</b>: Project names must not contain whitespace. Use at most 32 alphanumeric characters or hyphen or underscore: "a-zA-Z0-9_-".</b></p>';
+echo '<p><b>Note</b>: Project names must not contain whitespace. Use at least 2 and most 32 alphanumeric characters or hyphen or underscore.</b></p>';
 echo '<p><b>Note: Project names are public, global and permanent</b>; there can only ever be a single project with a given name, and that name is visible to all registered users.</p>';
 echo '<p><b>Expiration</b>: The date when this project is closed, and slices will expire. Blank means no expiration.</p>';
 print "<p>\n";


### PR DESCRIPTION
Match the clearinghouse regex on project names. Update text
descriptions and error messages to match.

Fixes #1689 