### PR TITLE
Standardize python shebang

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Standardize python shebang declaration
+  ([#1367](https://github.com/GENI-NSF/geni-portal/issues/1367))
 
 ## Installation Notes
 

--- a/portal/gcf.d/src/omni_php.py
+++ b/portal/gcf.d/src/omni_php.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #----------------------------------------------------------------------
 # Copyright (c) 2012-2016 Raytheon BBN Technologies
@@ -34,7 +34,7 @@ def main(argv=None):
     parser = omni.getParser()
     # Parse Options
     (options, args) = parser.parse_args()
-    
+
     text, obj = omni.call( args, options )
 
     if type(obj) == type({}):
@@ -46,6 +46,6 @@ def main(argv=None):
     # serialize using json
     jsonObj = json.dumps( (text, obj2), indent=4 )
     print jsonObj
-        
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/portal/gcf.d/src/stitcher_php.py
+++ b/portal/gcf.d/src/stitcher_php.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 #----------------------------------------------------------------------
 # Copyright (c) 2012-2016 Raytheon BBN Technologies
@@ -48,7 +48,7 @@ def main(argv=None):
         start_file_handle.close()
     except (ValueError, IOError) as e:
         pass
-    
+
     # catch exceptions that stitcher.call may pass back
     try:
         text, obj = stitcher.call( sys.argv[1:] )
@@ -73,6 +73,6 @@ def main(argv=None):
             stop_file_handle.close()
         except (ValueError, IOError) as e:
             pass
-    
+
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Always use /usr/bin/env to find python.

Fixes #1367 
