### PR TITLE
Update the Jacks URL per Emulab's request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ## Changes
 
 * Add some notes to geni-fetch-aggmon for testing
+* Update the Jacks URL per Emulab's request
 
 ## Installation Notes
 

--- a/lib/php/settings.php.in
+++ b/lib/php/settings.php.in
@@ -51,7 +51,7 @@ $portal_version = "@VERSION@";
 
 // URL to the Jacks root
 // Stable
-$jacks_stable_url = "https://www.emulab.net/protogeni/jacks-stable/js/jacks";
+$jacks_stable_url = "https://www.emulab.net/protogeni/jacks-stable/js/jacks.js";
 //$jacks_stable_url = "https://portal.geni.net/jacks-stable/js/jacks";
 
 // Sources for external libraries the portal uses


### PR DESCRIPTION
Add the .js extension to the Jacks URL. We don't know why it works
without the extension, and it stopped working when using the
temporary Emulab server. So add the extension to keep it working
long term, per the Emulab team.