### PR TITLE
Remove hardcoded help email from code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,11 @@
 ## Changes
 
 * Add some notes to geni-fetch-aggmon for testing
+  ([#1703](https://github.com/GENI-NSF/geni-portal/issues/1703))
 * Update the Jacks URL per Emulab's request
+  ([#1704](https://github.com/GENI-NSF/geni-portal/issues/1704))
+* Remove hardcoded help email from code
+  ([#1709](https://github.com/GENI-NSF/geni-portal/issues/1709))
 
 ## Installation Notes
 

--- a/ch/www/index.html
+++ b/ch/www/index.html
@@ -5,10 +5,10 @@
     <title>Default site page</title>
   </head>
   <body>
-    You have reached a GENI page for a domain which is not in use.  If
-    you believe you have reached this page in error, or if you
-    received an e-mail directing you to access this page, please
-    contact
-    <a href="mailto:portal-help@geni.net">portal-help@geni.net</a>.
+    You have reached a GENI page for a domain which is not in use.
+    Please visit the
+    <a href="http://groups.geni.net/geni/wiki/GENIExperimenter/GetHelp">
+            GENI Help Page
+    </a> for assistance.
   </body>
 </html>

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,7 @@
-AC_INIT([geni-ch], [3.15], [portal-help@geni.net])
+# Specify package name, version, bug report URL, tar name, and URL
+AC_INIT([GENI Clearinghouse], [3.15],
+        [https://github.com/GENI-NSF/geni-portal/issues], [geni-ch],
+	[https://github.com/GENI-NSF/geni-ch])
 #AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 #AM_INIT_AUTOMAKE([foreign -Wall])
 AM_INIT_AUTOMAKE([foreign -Wall -Wno-portability])

--- a/kmtool/www/kmtool/kmnoemail.php
+++ b/kmtool/www/kmtool/kmnoemail.php
@@ -24,6 +24,8 @@
 
 include("kmheader.php");
 include("util.php");
+include_once('/etc/geni-ch/settings.php');
+
 $eppn = strtolower($_SERVER['eppn']);
 ?>
 
@@ -35,16 +37,16 @@ resources.
 <br/>
 <br/>
 If you would like to register for a GENI account, please self-assert
-your <em>institutional email address</em> by
-<a href="mailto:portal-help@geni.net?subject=Self-asserted email address for EPPN
+your <em>school or company email address</em> by
+<a href="mailto:<?php echo $portal_help_email;?>?subject=Self-asserted email address for EPPN
 <?php
 print " $eppn";
 ?>
-&body=I would like to register for a GENI account. This email was sent from my institutional email address.">
+&body=I would like to register for a GENI account. This email was sent from my school or company email address.">
 sending an email
 </a>
-to portal-help@geni.net from your institutional email address. Make sure the
-email you send includes your
+to <?php echo $portal_help_email;?> from your school or company email address.
+Make sure the email you send includes your
 <a href="http://www.incommon.org/federation/attributesummary.html#eduPersonPrincipal">EPPN</a>, which is:
 <br/><br/>
 

--- a/portal/www/portal/contact-us.php
+++ b/portal/www/portal/contact-us.php
@@ -38,8 +38,6 @@ $hostname = $_SERVER['SERVER_NAME'];
 
 <h2>Contact Us</h2>
 
-<p>For feedback, issues and questions about the GENI Portal please email <a href="mailto:portal-help@geni.net">portal-help@geni.net</a>.</p>
-
 <p>For technical assistance or advice about your GENI experiment please email the community forum  <a href="mailto:geni-users@googlegroups.com"> geni-users@googlegroups.com</a>.
 If you are not already a member please <a href="https://groups.google.com/forum/#!forum/geni-users" target="_blank">register</a> to be able to receive the responses.</p>
 

--- a/portal/www/portal/do-modify.php
+++ b/portal/www/portal/do-modify.php
@@ -253,7 +253,7 @@ print '<p><b>Your account information has been updated.</b></p>';
 if ($pi_request and ! $is_pi) {
   if ($duplicateRequest) {
     print "<p>You already have one outstanding request. You should hear from us within 3-4 business days of your original request.</p>";
-    print "<p>Email <a href='mailto:portal-help@geni.net'>GENI Portal Help</a> if you have questions.</p>";
+    print "<p>Please <a href='contact-us.php'>contact us</a> if you have questions.</p>";
   } else {
     print '<p>' . PHP_EOL;
     print "Your Project Lead request has been received.";

--- a/portal/www/portal/error-text.php
+++ b/portal/www/portal/error-text.php
@@ -49,7 +49,7 @@ if (key_exists("error", $_GET)) {
   echo "<p class='warn'>" . $error_text . "</p><br/>\n";
 } else {
   // error_log('$_SERVER = ' . print_r($_SERVER, true));
-  
+
   foreach ($_GET as $line_num => $line) {
     //  error_log("LINE_NUM " . $line_num);
     $text = str_replace('_', ' ', htmlspecialchars(urldecode($line_num)));
@@ -83,8 +83,9 @@ $mailto_query_string = http_build_query($mailto_params);
    RFC3986 encoding. */
 $mailto_query_string = str_replace('+', '%20', $mailto_query_string);
 
-print "<a href='mailto:portal-help@geni.net?$mailto_query_string'>";
-print "Need help? Report a problem?</a>\n";
+print "Need help?\n";
+print "<a href='contact-us.php'>";
+print "Contact us</a>.\n";
 print "<br/>\n";
 print "<br/>\n";
 print "<form method=\"GET\" action=\"back\">\n";

--- a/portal/www/portal/help.php
+++ b/portal/www/portal/help.php
@@ -41,7 +41,6 @@ $hostname = $_SERVER['SERVER_NAME'];
 <li><a href="http://gmoc.grnoc.iu.edu/gmoc/index/support.html">GENI Meta-Operations Center (GMOC)</a> -- Create and search trouble tickets.  Calendar of planned and unplanned outages.</li>
 <li><a href="http://groups.geni.net/geni/wiki/GENIGlossary">GENI Glossary</a></li>
 <li><a href="/login-help.php">GENI Accounts and Portal Login Issues</a></li>
-<li><a href="mailto:portal-help@geni.net">Email Portal Help</a> for questions, comments or problems using this website.</li>
 <li><a href="mailto:help@geni.net">Email GENI Help</a> for questions or issues with GENI resources, designing experiments, or other general GENI issues.</li>
 </ul>
 <?php

--- a/portal/www/portal/send_bug_report.php
+++ b/portal/www/portal/send_bug_report.php
@@ -37,9 +37,9 @@ require_once("omni_invocation_constants.php");
 
 /*
     send_bug_report.php
-    
+
     Purpose: Sends bug report of omni invocation files to e-mail(s) specified
-    
+
     Accepts:
         Required:
             invocation_id: unique ID for an omni invocation (e.g. qlj7KS)
@@ -74,7 +74,7 @@ if (! count($_REQUEST)) {
 }
 
 // set user ID and invocation
-if(array_key_exists("invocation_id", $_REQUEST) && 
+if(array_key_exists("invocation_id", $_REQUEST) &&
         array_key_exists("invocation_user", $_REQUEST)) {
     $invocation_user = $_REQUEST['invocation_user'];
     $invocation_id = $_REQUEST['invocation_id'];
@@ -180,7 +180,7 @@ function send_bug_report_success($msg) {
     Handle zipping and mailing the bug report
 */
 function send_bug_report($user, $invocation_user, $invocation_id, $to, $cc, $custom_message) {
-    
+
     $omni_invocation_dir = get_invocation_dir_name($invocation_user, $invocation_id);
 
     // make sure directory actually exists
@@ -191,7 +191,7 @@ function send_bug_report($user, $invocation_user, $invocation_id, $to, $cc, $cus
     // don't include the user's cert, credentials, private key, and (maybe) SF cred
     $excluded_files_list = array(
         "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::SLICE_CREDENTIAL_FILE,
-        "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::CERTIFICATE_FILE, 
+        "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::CERTIFICATE_FILE,
         "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::PRIVATE_KEY_FILE,
         "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::SPEAKSFOR_CREDENTIAL_FILE
     );
@@ -206,7 +206,7 @@ function send_bug_report($user, $invocation_user, $invocation_id, $to, $cc, $cus
     // if .zip file exists, grab its contents for attachment and delete file
     $attachment = "";
     if($retVal) {
-        $attachment = chunk_split(base64_encode(file_get_contents($retVal)), 76, "\n"); 
+        $attachment = chunk_split(base64_encode(file_get_contents($retVal)), 76, "\n");
         if(file_exists($retVal)) {
             unlink($retVal);
         }
@@ -214,7 +214,7 @@ function send_bug_report($user, $invocation_user, $invocation_id, $to, $cc, $cus
     else {
         send_bug_report_error("Problem report files could not be zipped in an archive. Problem report not sent.");
     }
-    
+
     // prepare metadata
     $metadata = "";
     $metadata_file = "$omni_invocation_dir/" . OMNI_INVOCATION_FILE::METADATA_BUG_REPORT_EMAIL_FILE;
@@ -229,12 +229,12 @@ function send_bug_report($user, $invocation_user, $invocation_id, $to, $cc, $cus
 	  }
         }
     }
-    
+
     // set up e-mail
     $boundary_string = md5(date('r', time()));
     $from = "\"" . $user->prettyName() . " (via the GENI Portal)\" <www-data@gpolab.bbn.com>";
     $subject = "GENI Portal Reservation Problem Report";
-    
+
     $headers   = array();
     $headers[] = "MIME-Version: 1.0";
     $headers[] = "Content-type: multipart/mixed; boundary=\"PHP-mixed-" . $boundary_string . "\"";
@@ -278,8 +278,8 @@ Content-Disposition: attachment
 
 <?php echo $attachment; ?>
 
-<?php 
-    $message = ob_get_clean(); 
+<?php
+    $message = ob_get_clean();
     $message .= "\r\n";
     $message .= "--PHP-mixed-$boundary_string--\r\n";
 
@@ -297,7 +297,7 @@ Content-Disposition: attachment
     else {
         error_log("Error sending problem report $invocation_user-$invocation_id: $retVal");
         send_bug_report_error("Could not send problem report. Try again later or " .
-            "please contact <a href='mailto:portal-help@geni.net'>Portal Help</a>.");
+            "please <a href='contact-us.php'>contact us</a> for assistance.");
     }
 
 }

--- a/portal/www/portal/slice-add-resources-jacks.js
+++ b/portal/www/portal/slice-add-resources-jacks.js
@@ -97,7 +97,7 @@ function handle_rspec_validation_results(jsonResponse)
 	if(jsonResponse.partially_bound) {
 	    set_attributes_for_partially_bound();
 	    disable_reserve_resources();
-	} 
+	}
 	else if(jsonResponse.stitch) {
 	    set_attributes_for_stitching();
 	    enable_reserve_resources();
@@ -117,7 +117,7 @@ function handle_rspec_validation_results(jsonResponse)
 	set_attributes_for_unbound();
 	disable_reserve_resources();
     }
-        
+
 }
 
 function handle_rspec_update(jsonResponse, rspec, updateJacks)
@@ -337,13 +337,11 @@ function jacks_fetch_topology_callback(rspecs) {
       jacksEditorApp.downloadingRspec = false;
       $.post("saverspectoserver.php", {rspec : rspec},
 	    function(rt, st, xhr) {
-		//		console.log("SUCCESS");
 		var replace_url = "rspecdownload.php?tempfile=" + rt + "&slice_name=" + jacksEditorApp.sliceName;
 		window.location.replace(replace_url);
 	    })
 	  .fail(function(xhr, ts, et) {
-		  //		  console.log("FAILURE");
-              alert("An error occurred. Please notify portal-help@geni.net.");
+              $( "#downloadErrorDialog" ).dialog("open");
 	      });
   } else if (jacksEditorApp.submittingRspec) {
       jacksEditorApp.submittingRspec = false;
@@ -383,7 +381,7 @@ function jacks_modified_topology_callback(data)
     rspec = data.rspec;
     current_rspec = $('#current_rspec_text').val();
     // Are we in the middle of loading an RSpec from editor?
-    loading_rspec = $('#loading_rspec').val(); 
+    loading_rspec = $('#loading_rspec').val();
 
     // Strip all newlines from rspec. Jacks may transform original rspec newlines.
     rspec = rspec.replace(/\r?\n|\r/g, '');
@@ -393,7 +391,7 @@ function jacks_modified_topology_callback(data)
     //    console.log("JMTC NODES = " + data.nodes.length + " LINKS = " + data.links.length + " SITES = " + data.sites.length + " RSPEC = " + rspec.length + " CR = " + current_rspec.length + " LOADING = " + loading_rspec + " RST = " + rspec.trim().length + " CST = " + current_rspec.trim().length + " SAME = " + (rspec == current_rspec));
 
 
-    // Clear out slice-add-resources menus when 
+    // Clear out slice-add-resources menus when
     // action on jacks (delete all, adding/removing node or link)
     // makes displayed file/RSpec/URL/text inconsistent with Jacks topology
     if (loading_rspec != "1" && (rspec != current_rspec)) {
@@ -411,12 +409,12 @@ function jacks_modified_topology_callback(data)
     // id, client_id
     links = data.links;
 
-    // id, name, urn 
+    // id, name, urn
     // Note: site.name = node.site_name, node.aggregate_id = site.urn
     sites = data.sites;
 
     // RSpec is bound IFF every node has an aggregate_id, or every site has a urn
-    // call validate_rspec_file if we've changed from bound 
+    // call validate_rspec_file if we've changed from bound
     // to either partially bound or bound
     validate_rspec_file(rspec, false, handle_validation_results_no_jacks);
 }
@@ -507,8 +505,8 @@ function urlupload_onchange()
     // console.log("URLUPLOAD");
     $('#loading_rspec').val("1");
     var url = $('#url_select').val().trim();
-    $.get("upload-file.php", 
-	  {url : url}, 
+    $.get("upload-file.php",
+	  {url : url},
               function(rt, st, xhr) {
 		  var rspec = xhr.responseText;
 		  validate_rspec_file(rspec, false, handle_validation_results);
@@ -555,11 +553,11 @@ function do_rspec_download()
 // with current topology
 function do_editor_expand(restore)
 {
-    var editor_url = "jacks-editor-app-expanded.php?slice_id=" + 
+    var editor_url = "jacks-editor-app-expanded.php?slice_id=" +
 	jacks_slice_id;
 
     if (restore == true)
-	editor_url = "slice-add-resources-jacks.php?slice_id=" + 
+	editor_url = "slice-add-resources-jacks.php?slice_id=" +
 	    jacks_slice_id;
 
     jacksEditorApp.passingContextToURL = editor_url;
@@ -637,7 +635,7 @@ function do_selection_duplicate_internal(include_links)
 	    }
 	}
 
-	// New name is from old name plus "-$UNIQUE_COUNTER", 
+	// New name is from old name plus "-$UNIQUE_COUNTER",
 	// skipping over any existing nodes with that manufactured name
 	var new_node_name = construct_new_node_name(selected_node_name, all_node_names);
 	all_node_names.push(new_node_name);
@@ -700,7 +698,7 @@ function do_selection_duplicate_internal(include_links)
 
 		if (link_for_interface != null) {
 		    // Make a new name for the interface
-		    var new_interface_name = new_node_name + ":if" + 
+		    var new_interface_name = new_node_name + ":if" +
 			iface_index;
 
 		    // Add a new interface ref to the link
@@ -712,7 +710,7 @@ function do_selection_duplicate_internal(include_links)
 		    $(interface).attr('client_id', new_interface_name);
 		}
 	    }
-	    
+
 	} else {
 	    // If we're not including links, we need to eliminate the interfaces from the cloned node
 	    $(cloned_rspec_node).find('interface').remove();
@@ -784,7 +782,7 @@ function do_auto_ip_assignment_internal()
 	var num_iface_ref_elts = iface_ref_elts.length;
 
 	if (num_iface_ref_elts > 255) {
-	    alert("Can't perform AUTO_IP assignment with " + 
+	    alert("Can't perform AUTO_IP assignment with " +
 		  "> 255 interfaces per link ");
 	    return;
 	}
@@ -893,7 +891,7 @@ function validateSubmit()
 
   //  console.log("validateSubmit.rspec = " + current_rspec_text);
   //  console.log("validateSubmit.bound = " + is_bound);
-  
+
   if ((current_rspec_text != '') && is_bound) {
     f1.submit();
     return true;
@@ -905,4 +903,3 @@ function validateSubmit()
     return false;
   }
 }
-

--- a/portal/www/portal/slice-add-resources-jacks.php
+++ b/portal/www/portal/slice-add-resources-jacks.php
@@ -150,7 +150,7 @@ print "</div></td></tr></table>";
   var jacks_slice_id = <?php echo json_encode($slice_id) ?>;
   var jacks_slice_name = <?php echo json_encode($slice_name) ?>;
 
-  var jacks_slice_info = {slice_id : jacks_slice_id, 
+  var jacks_slice_info = {slice_id : jacks_slice_id,
 			  slice_name : jacks_slice_name};
 
   var jacks_user_name = <?php echo json_encode($user->username) ?>;
@@ -185,7 +185,7 @@ if ($am_ids == null) {
 enable_rspec_selection_mode_portal();
 var am_id = <?php echo $am_id ?>;
 if (am_id && $('#agg_chooser option[value="'+am_id+'"]').length > 0) {
-  $('#agg_chooser').val(am_id); 
+  $('#agg_chooser').val(am_id);
 }
 </script>
 <script>
@@ -246,5 +246,32 @@ echo "</div>";
 // END the tabContent class
   echo "</div>";
 
+?>
+<?php
+  // This is a jQueryUI dialog box to show when there is an error
+  // downloading the RSpec. The div is not displayed on the page.
+  // The "tabindex" on the <a> tag is to prevent the link from having
+  // focus when the dialog appears, which looks ugly. Instead, the
+  // OK button has the focus.
+?>
+  <div id="downloadErrorDialog" title="Download Error">
+    <p>An error occurred. Please <a href="contact-us.php" tabindex="-1">contact us</a>
+    for assistance.</p>
+  </div>
+  <script>
+  $(function() {
+          $( "#downloadErrorDialog" ).dialog({ autoOpen: false,
+                  buttons: [
+            {
+              text: "OK",
+              click: function() {
+                $( this ).dialog( "close" );
+              }
+            }
+          ] });
+  })
+  </script>
+
+<?php
 include("footer.php");
 ?>

--- a/portal/www/portal/sliceresource.php
+++ b/portal/www/portal/sliceresource.php
@@ -228,7 +228,10 @@ function validateBugReportSubmit()
 <li>The report will not include security-sensitive information such as slice credentials, certificates, private keys and SpeaksFor credentials.</li>
 </ul>
 
-<p>If you are not comfortable sharing your problem report outside the GENI Project Office, email it to <a href="mailto:portal-help@geni.net">portal-help@geni.net</a>.</p>
+<p>If you are not comfortable sharing your problem report publicly, email it to
+  <a href="mailto:<?php echo $portal_help_email;?>">
+          <?php echo $portal_help_email;?></a>.
+</p>
 
 <form id="f1" action="send_bug_report.php" method="post" enctype="multipart/form-data" onsubmit="return validateBugReportSubmit()">
 <input type="hidden" name="invocation_id" id="invocation_id" value="<?php echo $invocation_id;?>"/>

--- a/portal/www/portal/sliceresource.php
+++ b/portal/www/portal/sliceresource.php
@@ -58,7 +58,7 @@ if (! count($_REQUEST)) {
 }
 
 // set user ID and invocation
-if(array_key_exists("invocation_id", $_REQUEST) && 
+if(array_key_exists("invocation_id", $_REQUEST) &&
         array_key_exists("invocation_user", $_REQUEST)) {
     $invocation_user = $_REQUEST['invocation_user'];
     $invocation_id = $_REQUEST['invocation_id'];
@@ -98,9 +98,13 @@ include("tool-showmessage.php");
 $dir_to_check = get_invocation_dir_name($invocation_user, $invocation_id);
 if(!is_dir($dir_to_check)) {
     echo "<h1>Add Resources to GENI Slice <i>$slice_name</i> (Results)</h1>";
-    echo "<p class='error'>Files and process data related to omni request <b>$invocation_user-$invocation_id</b> not found. Note that older files are periodically removed from the Portal, so it is possible that the files and process-related data have been deleted as part of routine maintenance.<br><br>For further help, please contact <a href='mailto:portal-help@geni.net'>Portal Help</a>.</p>";
-    
-    
+    echo "<p class='error'>Files and process data related to omni request";
+    echo " <b>$invocation_user-$invocation_id</b> not found.";
+    echo " Older files are periodically removed from the Portal, so it is possible that the files";
+    echo " and process-related data have been deleted as part of routine maintenance.";
+    echo "<br><br>";
+    echo "Please <a href='contact-us.php'>contact us</a> if you require further assistance.</p>";
+
     echo '<form method="GET" action="back">';
     echo '<input type="button" value="Back" onClick="history.back(-1)"/>';
     echo '</form>';
@@ -120,7 +124,7 @@ $bug_report_subject = "GENI Portal Reservation Problem Report";
     set if tool-lookupids.php hasn't already set it - there's no else clause
     in tool-lookupids.php because the assumption is that the page would have
     already shown an error earlier if $REQUEST['am_id'] hadn't been specified
-*/ 
+*/
 if(!isset($am_id)) {
     $am_id = NULL;
 }
@@ -195,7 +199,7 @@ function validateBugReportSubmit()
   f1 = document.getElementById("f1");
   to = document.getElementById("to");
   message = document.getElementById("message");
-  
+
   if (to.value && message.value) {
     f1.submit();
     return true;

--- a/portal/www/portal/sliceresource.php
+++ b/portal/www/portal/sliceresource.php
@@ -218,7 +218,10 @@ function validateBugReportSubmit()
 
 <h2>Send a Problem Report</h2>
 
-<p>Ran into a problem or have a question? Search the <a target="_blank" href="https://groups.google.com/forum/#!forum/geni-users">GENI Users</a> archives for answers to similar questions.  If you cannot find an answer, join the <a target="_blank" href="http://groups.geni.net/geni/wiki/GENIExperimenter/CommunityMailingList"> geni-users mailing list</a> and send your problem report there.</p>
+<p>Ran into a problem or have a question? Search the
+  <a target="_blank" href="https://groups.google.com/forum/#!forum/geni-users">
+    GENI Users</a> archives for answers to similar questions.
+</p>
 
 <ul>
 <li>The problem report will include your name, e-mail address, slice and project information, request RSpec, manifest RSpec(s), progress log, debug log, error log and process metadata.</li>

--- a/portal/www/portal/speaks-for.js
+++ b/portal/www/portal/speaks-for.js
@@ -22,6 +22,8 @@
  *----------------------------------------------------------------------
  */
 var portal = {};
+/* This should be set by the embedding page. */
+portal.helpEmail = null;
 portal.authorize = function()
 {
   var tool_urn = document.getElementById('toolurn').innerHTML;
@@ -63,7 +65,11 @@ portal.authZResponse = function(speaks_for_cred)
       if (data.status == 406) {
           alert('An error occurred storing your credential. Please use your GENI certificate to sign the credential.');
       } else {
-          alert('An error occurred storing your credential. Please contact portal-help@geni.net');
+          msg = 'An error occurred storing your credential.';
+          if (portal.helpEmail) {
+              msg += ' Please contact ' + portal.helpEmail;
+          }
+          alert(msg);
       }
     });
 }

--- a/portal/www/portal/speaks-for.php
+++ b/portal/www/portal/speaks-for.php
@@ -110,12 +110,13 @@ show_header('GENI Portal: Authorization', FALSE);
 <script type="text/plain" id="toolcert"><?php echo $toolcert;?></script>
 <script type="text/plain" id="ma_url"><?php echo $ma_url;?></script>
 <script type="text/plain" id="ma_name"><?php echo $ma_name;?></script>
+<script type="text/javascript" src="speaks-for.js"></script>
 <script type="text/javascript">
 /* Override the genilib defaults for our trusted host. */
 genilib.trustedHost = '<?php echo $genilib_trusted_host;?>';
 genilib.trustedPath = '<?php echo $genilib_trusted_path;?>';
+portal.helpEmail = '<?php echo $portal_help_email;?>';
 </script>
-<script type="text/javascript" src="speaks-for.js"></script>
 <link rel="stylesheet" type="text/css" href="speaks-for.css" />
 
 <?php

--- a/templates/settings.php.tmpl
+++ b/templates/settings.php.tmpl
@@ -37,6 +37,11 @@ $db_dsn = 'pgsql://@db_user@:@db_pass@@@db_host@/@db_name@';
 $portal_admin_email = 'portal-admin@example.com';
 
 /*
+ * How users can get help via email.
+ */
+$portal_help_email = 'portal-help@example.com'
+
+/*
  * Bootstrap the service registry. All other services are discovered
  * via the service registry.
  */


### PR DESCRIPTION
Switch to a configuration parameter for the help email. Use the parameter where appropriate. Also switch some occurrences of an email address over to a "contact us" URL to give the user more options.