### PR TITLE
Issue #1673: Make self asserting an email address be self-service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,10 @@
 
 ## Installation Notes
 
-* None
+* Update KM database to add new table for email address self-service:
+    ```
+    psql -U portal -h localhost portal < /usr/share/geni-ch/km/db/postgresql/update-2.sql
+    ```
 
 # [Release 3.14](https://github.com/GENI-NSF/geni-portal/milestones/3.14)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changes
 
+* Allow self service assertion of email address
+  ([#1673](https://github.com/GENI-NSF/geni-portal/issues/1673))
 * Provide a way to update SSH keys on existing resources
   ([#1393](https://github.com/GENI-NSF/geni-portal/issues/1393))
 * Add some notes to geni-fetch-aggmon for testing

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -59,6 +59,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/%{legacy_name}/ch/www/salist.json
 %{_datadir}/%{legacy_name}/km/db/postgresql/schema.sql
 %{_datadir}/%{legacy_name}/km/db/postgresql/update-1.sql
+%{_datadir}/%{legacy_name}/km/db/postgresql/update-2.sql
 %{_datadir}/%{legacy_name}/lib/php/abac.php
 %{_datadir}/%{legacy_name}/lib/php/aggstatus.php
 %{_datadir}/%{legacy_name}/lib/php/am_client.php
@@ -396,6 +397,8 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/kmheader.php
 %{webdir}/secure/kmhome.php
 %{webdir}/secure/kmnoemail.php
+%{webdir}/secure/kmsendemail.php
+%{webdir}/secure/kmconfirmemail.php
 %{webdir}/secure/listresources.php
 %{webdir}/secure/listresources_plain.php
 %{webdir}/secure/loadcert.js

--- a/kmtool/Makefile.am
+++ b/kmtool/Makefile.am
@@ -6,7 +6,8 @@ svcwebdir = /var/www/secure
 svccssdir = /var/www/common/css
 
 nobase_dist_svcdata_DATA = db/postgresql/schema.sql \
-	db/postgresql/update-1.sql
+	db/postgresql/update-1.sql \
+	db/postgresql/update-2.sql
 
 dist_svcweb_DATA = \
 	www/kmtool/kmfooter.php \
@@ -16,6 +17,8 @@ dist_svcweb_DATA = \
 	www/kmtool/kmheader.php \
 	www/kmtool/kmhome.php \
 	www/kmtool/kmnoemail.php \
+	www/kmtool/kmsendemail.php \
+	www/kmtool/kmconfirmemail.php \
 	www/kmtool/loadcert.js \
 	www/kmtool/loadcert.php \
 	www/kmtool/renewcert.php

--- a/kmtool/db/postgresql/schema.sql
+++ b/kmtool/db/postgresql/schema.sql
@@ -19,3 +19,17 @@ CREATE TABLE km_asserted_attribute (
 );
 
 CREATE INDEX km_asserted_attribute_eppn ON km_asserted_attribute (eppn);
+
+-- Table for people whose IdPs don't send email to self assert their address
+-- See kmnoemail.php
+
+DROP TABLE IF EXISTS km_email_confirm;
+
+CREATE TABLE km_email_confirm (
+    id SERIAL PRIMARY KEY,
+    eppn VARCHAR NOT NULL,
+    email VARCHAR NOT NULL,
+    nonce VARCHAR NOT NULL,
+    created timestamp DEFAULT (NOW() at time zone 'utc') NOT NULL
+);
+

--- a/kmtool/db/postgresql/update-2.sql
+++ b/kmtool/db/postgresql/update-2.sql
@@ -1,0 +1,11 @@
+-- Add table for self asserting email address
+
+DROP TABLE IF EXISTS km_email_confirm;
+
+CREATE TABLE km_email_confirm (
+    id SERIAL PRIMARY KEY,
+    eppn VARCHAR NOT NULL,
+    email VARCHAR NOT NULL,
+    nonce VARCHAR NOT NULL,
+    created timestamp DEFAULT (NOW() at time zone 'utc') NOT NULL
+);

--- a/kmtool/www/common/css/kmtool.css
+++ b/kmtool/www/common/css/kmtool.css
@@ -335,3 +335,108 @@ table .notapply {
 #mainnav .active :link:hover, #mainnav .active :visited:hover {
  border-right: 1px solid #000;
 }
+label {
+	font-weight: bold;
+	margin-right: 5px;
+}
+
+span.required {
+	color:red;
+}
+
+input {
+	margin-left: 5px;
+}
+form {
+  margin: 10px auto;
+}
+
+.card {
+  width: calc(100% - 40px);
+  background-color: #FFFFFF;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  padding: 20px;
+  margin: 25px 0px;
+  clear: both;
+  -webkit-transition-duration: 500ms;
+  transition-duration: 500ms;
+}
+
+.warn {
+  position: relative;
+  background-color: #FFFFFF;
+  border-left: 10px solid red;
+  color: #616161;
+  padding: 20px;
+  font-weight: normal;
+  margin-left: 0px !important;
+  margin-top: 20px !important;
+  margin-bottom: 20px !important;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+.warn:before {
+  content: "Warning";
+  color: red;
+  font-weight: bold;
+  display: block;
+  font-size: 1.1em !important;
+}
+
+.error {
+  position: relative;
+  background-color: #FFFFFF;
+  border-left: 10px solid red;
+  color: #616161;
+  padding: 20px;
+  font-weight: normal;
+  margin-left: 0px !important;
+  margin-top: 20px !important;
+  margin-bottom: 20px !important;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+}
+
+.error:before {
+  content: "Error";
+  color: red;
+  font-weight: bold;
+  display: block;
+  font-size: 1.1em !important;
+}
+
+#maintenance_alert {
+  border-radius: 0px;
+  margin: 20px auto 0px auto !important;
+  width: calc(95% - 50px);
+  max-width: 1350px;
+  min-width: 750px;
+}
+
+.closebutton {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}
+
+.material-icons {
+  display: inline;
+  vertical-align: middle;
+  font-size: 18px;
+  margin: 0px 3px;
+}
+
+.submenu li button {
+  border: 0px;
+  background-color: #FFFFFF !important;
+  display: block;
+  text-decoration: none !important;
+  color: #303030 !important;
+  width: 100%;
+  margin: 0px;
+  height: 30px;
+  line-height: 30px;
+  font-size: 13px;
+  box-shadow: none;
+  padding: 0px;
+}
+

--- a/kmtool/www/kmtool/kmconfirmemail.php
+++ b/kmtool/www/kmtool/kmconfirmemail.php
@@ -1,0 +1,149 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2016 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+
+// Step 3 of handling user who must self assert their email address
+// This is the target page of the confirmation email we send.
+// Assuming the link matches the current EPPN,
+// the given email address is inserted in km_asserted_attribute,
+// so that other Portal pages will use that and proceed.
+// Step 1 is kmnoemail, Step 2 is kmsendemail
+
+include("util.php");
+include_once('/etc/geni-ch/settings.php');
+require_once 'maintenance_mode.php';
+require_once 'km_utils.php';
+require_once 'response_format.php';
+require_once 'db_utils.php';
+require_once 'portal.php';
+
+// If this is a valid nonce/id for this EPPN, then
+// put this entry in the km_asserted_attributes table,
+// and remove it from km_email_confirm
+// Returns user's email if confirmation link was valid, null otherwise.
+function confirm_email($nonce, $db_id, $eppn) {
+    $db_conn = db_conn();
+    $sql = "SELECT * from km_email_confirm "
+      . "where id =" . $db_conn->quote($db_id, 'integer')
+      . " and eppn = " . $db_conn->quote($eppn, 'text')
+      . " and nonce =" . $db_conn->quote($nonce, 'text');
+    $db_result = db_fetch_row($sql, "get km_email_confirm");
+    if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+        $result = $db_result[RESPONSE_ARGUMENT::VALUE];
+	if (is_null($result)) {
+	  error_log("Found no email confirmation record for id $db_id, nonce $nonce, eppn $eppn");
+          return null;
+	}
+        $email = $result['email'];
+	$asserter = Portal::getUid();
+	$sql2 = "insert into km_asserted_attribute (eppn, name, value, asserter_id) select "
+	  . $db_conn->quote($eppn, 'text') . ", 'mail', " . $db_conn->quote($email, 'text')
+	  . ", " . $db_conn->quote($asserter, 'text')
+	  . " where not exists (select 1 from km_asserted_attribute where name='mail' and eppn= "
+	  . $db_conn->quote($eppn, 'text') . ") returning value";
+        $update_result = db_fetch_row($sql2, "insert into km_asserted_attribute confirmed email");
+        if ($update_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+            delete_confirmation($db_id, $nonce);
+	    $email = $update_result[RESPONSE_ARGUMENT::VALUE]['value'];
+	    return $email;
+        } else {
+            error_log("Failed to insert self asserted email address for $eppn: " .
+                      $update_result[RESPONSE_ARGUMENT::OUTPUT]);
+            return null;
+        }
+    } else {
+        error_log("Error getting KM email confirm record for eppn $eppn: "
+                 . $db_result[RESPONSE_ARGUMENT::OUTPUT]);
+        return null;
+    }
+}
+
+// Once email is confirmed, delete the entry from km_email_confirm
+function delete_confirmation($id, $nonce) {
+    $db_conn = db_conn();
+    $sql = "delete from km_email_confirm"
+         . " where id = " . $db_conn->quote($id, 'text')
+         . " and nonce = " . $db_conn->quote($nonce, 'text');
+    $result = db_execute_statement($sql);
+    if ($result[RESPONSE_ARGUMENT::CODE] != RESPONSE_ERROR::NONE) {
+        error_log("Error deleting old records: "
+                  . $result[RESPONSE_ARGUMENT::OUTPUT]);
+    }
+    return $result == RESPONSE_ERROR::NONE;
+}
+
+// If no eppn, go directly to InCommon error page
+if (! key_exists('eppn', $_SERVER)) {
+  $feh_url = incommon_feh_url();
+  header("Location: $feh_url");
+  exit;
+}
+
+$eppn = strtolower($_SERVER['eppn']);
+
+// Use the mail path if we are getting email
+if (key_exists('mail', $_SERVER)) {
+  relative_redirect('dashboard.php');
+}
+
+// If the email has already been asserted, use the main route in
+$asserted_attrs = get_asserted_attributes($eppn);
+if (key_exists('mail', $asserted_attrs)) {
+  relative_redirect('dashboard.php');
+}
+
+if (array_key_exists('n', $_REQUEST) && array_key_exists('id', $_REQUEST)) {
+    $nonce = $_REQUEST['n'];
+    $db_id = $_REQUEST['id'];
+} else {
+  error_log("Bad URL: missing args");
+  relative_redirect('kmnoemail.php');
+}
+
+// So we have an EPPN but no email from Shib or from asserted attribute
+
+// Bail if we're in maintenance
+if ($in_maintenance_mode) {
+  include("kmheader.php");
+  print "This GENI Clearinghouse is currently in maintenance mode and cannot register new users.";
+  print "<br>";
+  print "<button onClick=\"history.back(-1)\"><b>Back</b></button>";
+  include("kmfooter.php");
+  return;
+}
+
+list($email, $acctreq_id) = confirm_email($nonce, $db_id, $eppn);
+
+if($email != "") {
+  $_SESSION['lastmessage'] = "Email address successfully confirmed";
+  relative_redirect('dashboard.php');
+} else {
+  include("kmheader.php");
+  print "<h2>Email Address Confirmation Error</h2>";
+  print "<p>Could not confirm email. ";
+  print "Please <a href=\"" . relative_url('kmnoemail.php') . "\">try again</a>, or contact us at";
+  print " <a href=\"mailto:$portal_help_email\">$portal_help_email</a>.</p>\n";
+  include("kmfooter.php");
+}
+
+?>

--- a/kmtool/www/kmtool/kmheader.php
+++ b/kmtool/www/kmtool/kmheader.php
@@ -38,6 +38,7 @@ $title = 'GPO Member Authority';
 
   /* Stylesheet(s) */
   echo '<link type="text/css" href="/common/css/kmtool.css" rel="stylesheet"/>';
+  echo '<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Droid+Sans+Mono|Material+Icons" rel="stylesheet" type="text/css">';
 
   /* Close the "head" */
   echo '</head>';

--- a/kmtool/www/kmtool/kmnoemail.php
+++ b/kmtool/www/kmtool/kmnoemail.php
@@ -22,51 +22,123 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 
-include("kmheader.php");
+// Handle a user where we get an EPPN from their Shibboleth IdP,
+// but no email address; some schools don't send that for students.
+// On this page, request they enter their email address.
+// This page directs to
+// Step 2: kmsendemail, which emails them a confirmation link to
+// Step 3: kmconfirmemail, which enters their email address in the DB,
+// for use by later pages.
+
 include("util.php");
 include_once('/etc/geni-ch/settings.php');
+require_once 'maintenance_mode.php';
+require_once 'km_utils.php';
+
+// If no eppn, go directly to InCommon error page
+if (! key_exists('eppn', $_SERVER)) {
+  $feh_url = incommon_feh_url();
+  header("Location: $feh_url");
+  exit;
+}
 
 $eppn = strtolower($_SERVER['eppn']);
+
+// Use the mail path if we are getting email
+if (key_exists('mail', $_SERVER)) {
+  relative_redirect('dashboard.php');
+}
+
+// If the email has already been asserted, use the main route in
+$asserted_attrs = get_asserted_attributes($eppn);
+if (key_exists('mail', $asserted_attrs)) {
+  error_log("Already have asserted email");
+  relative_redirect('dashboard.php');
+}
+
+// So we have an EPPN but no email from Shib or from asserted attribute
+
+include("kmheader.php");
+
+// Bail if we're in maintenance
+if ($in_maintenance_mode) {
+  print "This GENI Clearinghouse is currently in maintenance mode and cannot register new users.";
+  print "<br>";
+  print "<button onClick=\"history.back(-1)\"><b>Back</b></button>";
+  include("kmfooter.php");
+  return;
+}
+
+// Clear out requests older than $hours hours in km_email_confirm
+function delete_expired_assertions($hours) {
+    $sql = "delete from km_email_confirm";
+    $sql .= " where created <";
+    $sql .= "  (now()  at time zone 'utc') - interval '$hours hours';";
+    $result = db_execute_statement($sql);
+    if ($result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+        $rows = $result[RESPONSE_ARGUMENT::VALUE];
+        error_log("Deleted $rows old records");
+    } else {
+        error_log("Error deleting old records: "
+                  . $result[RESPONSE_ARGUMENT::OUTPUT]);
+    }
+    return $result == RESPONSE_ERROR::NONE;
+}
+
+// Requests are good for a week - delete old ones now
+delete_expired_assertions(7*24);
+
+// kmsendemail sends us back here as needed with bademail
+if (key_exists('bademail', $_REQUEST)) {
+  // Set up the error display
+  $_SESSION['lasterror'] = "Invalid email address given";
+}
+
+// Get any partially asserted email from the DB
+// to pre-fill in the form
+$email = "";
+$db_conn = db_conn();
+$sql = "SELECT email from km_email_confirm "
+  . "where  eppn = " . $db_conn->quote($eppn, 'text');
+$db_result = db_fetch_row($sql, "get km_email_confirm");
+if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+  $result = $db_result[RESPONSE_ARGUMENT::VALUE];
+  if (! is_null($result)) {
+    $email = $result['email'];
+  }
+}
+
+include("tool-showmessage.php");
+
+// Here we show a form asking for their email
+// This page sends to kmsendmail.php
 ?>
 
-<h2>No email address</h2>
-Your identity provider is not sharing your email address with us.
+<h2>No Email Address</h2>
+<p>Your identity provider is not sharing your email address with us.
 <a href="http://www.geni.net">GENI</a> requires an email address
 so that you can be contacted if necessary about your reserved
-resources.
-<br/>
-<br/>
-If you would like to register for a GENI account, please self-assert
-your <em>school or company email address</em> by
-<a href="mailto:<?php echo $portal_help_email;?>?subject=Self-asserted email address for EPPN
-<?php
-print " $eppn";
-?>
-&body=I would like to register for a GENI account. This email was sent from my school or company email address.">
-sending an email
-</a>
-to <?php echo $portal_help_email;?> from your school or company email address.
-Make sure the email you send includes your
-<a href="http://www.incommon.org/federation/attributesummary.html#eduPersonPrincipal">EPPN</a>, which is:
-<br/><br/>
-
-<b>
-<?php
-print $eppn;
-?>
-</b>
-<br/>
-<br/>
-Your email will be reviewed and you will receive a response from a GENI
-administrator about how to proceed.
-<br/>
-<br/>
-<a href="
+resources.</>
+<p>If you would like to register for a GENI account, please self-assert
+  your email address:</p>
+  <form action="kmsendemail.php" method="POST">
+    <p><span class="required">*</span> = required</p>
+    <p><label class="input">Email address:<span class="required">*</span>
+        <input name="assertedemail" type="email" size="35" required value="<?php echo $email; ?>"></label>
+      <br>(Your school or organization email address is preferred.)
+    </p>
+    <input type="submit"/>
+  </form>
+<p>
+Questions? Contact 
+<a href="<?php echo $portal_help_email;?>"><?php echo $portal_help_email;?></a>.
+</p>
+<p><a href="
 <?php
 // Link to InCommon federated error handling service.
 print incommon_feh_url();
 ?>
-">Technical Information</a>
+">Technical Information</a></p>
 <?php
 include("kmfooter.php");
 ?>

--- a/kmtool/www/kmtool/kmnoemail.php
+++ b/kmtool/www/kmtool/kmnoemail.php
@@ -118,7 +118,7 @@ include("tool-showmessage.php");
 <p>Your identity provider is not sharing your email address with us.
 <a href="http://www.geni.net">GENI</a> requires an email address
 so that you can be contacted if necessary about your reserved
-resources.</>
+resources.</p>
 <p>If you would like to register for a GENI account, please self-assert
   your email address:</p>
   <form action="kmsendemail.php" method="POST">

--- a/kmtool/www/kmtool/kmsendemail.php
+++ b/kmtool/www/kmtool/kmsendemail.php
@@ -1,0 +1,207 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2016 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+
+// Step 2 in a user self asserting their email address
+// This is the target of the form that puts the record in the database,
+// and sends the user email
+// Step 1 is kmnoemail, and Step 3 is kmconfirmeail
+
+include("util.php");
+include_once('/etc/geni-ch/settings.php');
+require_once 'maintenance_mode.php';
+require_once 'km_utils.php';
+require_once 'response_format.php';
+require_once 'db_utils.php';
+
+// If no eppn, go directly to InCommon error page
+if (! key_exists('eppn', $_SERVER)) {
+  $feh_url = incommon_feh_url();
+  header("Location: $feh_url");
+  exit;
+}
+
+$eppn = strtolower($_SERVER['eppn']);
+
+// Use the main path if we are getting email
+if (key_exists('mail', $_SERVER)) {
+  relative_redirect('dashboard.php');
+}
+
+// If the email has already been asserted, use the main route in
+$asserted_attrs = get_asserted_attributes($eppn);
+if (key_exists('mail', $asserted_attrs)) {
+  relative_redirect('dashboard.php');
+}
+
+// So we have an EPPN but no email from Shib or from asserted attribute
+
+// If we don't have an asserted email yet, go back
+if (! key_exists('assertedemail', $_REQUEST)) {
+  relative_redirect('kmnoemail.php');
+}
+
+$email = $_REQUEST['assertedemail'];
+
+// If the email is invalid, go back
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+  error_log("Invalid email address given");
+  relative_redirect('kmnoemail.php?bademail=True');
+}
+
+include("kmheader.php");
+
+// Bail if we're in maintenance
+if ($in_maintenance_mode) {
+  print "This GENI Clearinghouse is currently in maintenance mode and cannot register new users.";
+  print "<br>";
+  print "<button onClick=\"history.back(-1)\"><b>Back</b></button>";
+  include("kmfooter.php");
+  return;
+}
+
+// Here on we're setting up to store the email address
+// and them email to confirm it
+
+// Generate a random string (nums, uppercase, lowercase) of width $width
+function random_id($width=6) {
+    $result = '';
+    for ($i=0; $i < $width; $i++) { 
+        $result .= base_convert(strval(rand(0, 35)), 10, 36);
+    }
+    return strtoupper($result);
+}
+
+// make a new /kmconfirmemail.php?id=XXX&n=YYY link for use in email confirmation email
+function create_email_confirm_link($id1, $id2) {
+  return relative_url("kmconfirmemail.php?id=$id1&n=$id2");
+}
+
+// Insert the email address assertion into the km_email_confirm table
+// removing any previous entry
+function insert_email_confirm($email, $nonce, $eppn) {
+    $db_conn = db_conn();
+
+    // First, delete any old entry for the same EPPN
+    // - allowing user to fix a bad email address
+    $sql = "delete from km_email_confirm"
+      . " where eppn = " . $db_conn->quote($eppn, 'text');
+    $result = db_execute_statement($sql);
+    if ($result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+      $rows = $result[RESPONSE_ARGUMENT::VALUE];
+      if ($rows > 0) {
+	error_log("Deleted (to replace) $rows record(s) for $eppn from km_email_confirm");
+      }
+    }
+
+    // Instead of delete then insert, could add index on eppn and add
+    // this to the insert statement, but this doesn't add much
+    // on conflict (eppn) do update set email=$email, nonce=$nonce, created=NOW() at time zone 'utc'
+    // Now insert a new row
+    $sql = "insert into km_email_confirm (email, nonce, eppn) values (";
+    $sql .= $db_conn->quote($email, 'text');
+    $sql .= ', ';
+    $sql .= $db_conn->quote($nonce, 'text');
+    $sql .= ', ';
+    $sql .= $db_conn->quote($eppn, 'text');
+    $sql .= ") returning id, created";
+
+    $db_result = db_fetch_row($sql, "insert km_email_confirm");
+    $result = false;
+    if ($db_result[RESPONSE_ARGUMENT::CODE] == RESPONSE_ERROR::NONE) {
+        $result = $db_result[RESPONSE_ARGUMENT::VALUE];
+    } else {
+        error_log("Error inserting KM email confirm record: "
+                  . $db_result[RESPONSE_ARGUMENT::OUTPUT]);
+    }
+    return $result;
+}
+
+function get_user_conf_email_body($confirm_url) {
+  global $portal_help_email;
+  $body = 'Thank you for self asserting your email address for use with GENI. ';
+  $body .= "Please confirm your email address by clicking this link:\n\n $confirm_url \n\n";
+  $body .= "You will then be able to complete your GENI account creation.\n\n";
+  $body .= "Questions? Contact $portal_help_email.";
+  $body .= "\n\n";
+  $body .= "Thanks,\n";
+  $body .= "GENI Operations\n";
+  return $body;
+}
+
+// Email requester to confirm their email address
+// Note that we BCC portal admins
+function send_user_confirmation_email($user_email, $confirm_url) {
+  global $portal_help_email, $portal_admin_email;
+  $subject = "GENI Account Email Confirmation";
+  $body = get_user_conf_email_body($confirm_url);
+  $headers = "Reply-To: $portal_help_email" . "\r\n" . "Bcc: " . $portal_admin_email . "\r\n" . 
+    "Content-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit";
+  return mail($user_email, $subject, $body, $headers);
+}
+
+// Main body
+// Create a nonce for this email/eppn assertion
+// Insert or update a row in the DB with the new email and eppn
+
+$nonce = random_id(8);
+$db_result = insert_email_confirm($email, $nonce, $eppn);
+if ($db_result) {
+  $db_id = $db_result['id'];
+  $confirm_url = create_email_confirm_link($db_id, $nonce);
+  if (send_user_confirmation_email($email, $confirm_url)) {
+    
+    print "<h2>Email Address Asserted</h2>\n";
+    print "<p>\n";
+    print "A confirmation email has been sent to $email.</p>";
+    print "<p>Please confirm your email address by following the";
+    print " link in that email. If you do not receive an email";
+    print " within 24 hours, check your SPAM / junk mail folder. </p><p>Questions? Contact us at";
+    print " <a href=\"mailto:$portal_help_email\">$portal_help_email</a>.\n";
+    print "</p>\n";
+  } else {
+    // Failed to queue email
+    
+    // Notify admins  / put in log
+    error_log("Failed to send self asserted email confirmation email to " . $email . " for eppn " . $eppn);
+
+    // Produce the result page
+    print "<h2>Address Assertion failed</h2>";
+    print "<p> We are sorry, your email address assertion failed. ";
+    print "Please <a href=\"" . relative_url('kmnoemail.php') . "\">try again</a>, or contact us at";
+    print " <a href=\"mailto:$portal_help_email\">$portal_help_email</a>.\n";
+    print "</p>\n";
+  }
+} else {
+  // Notify admins  / put in log
+  error_log("Failed to insert into DB self asserted email confirmation request for " . $email . " and eppn " . $eppn);
+  
+  // Produce the result page
+  print "<h2>Address Assertion failed</h2>";
+  print "<p> We are sorry, your email address assertion failed. ";
+  print "Please <a href=\"" . relative_url('kmnoemail.php') . "\">try again</a>, or contact us at";
+  print " <a href=\"mailto:$portal_help_email\">$portal_help_email</a>.\n";
+  print "</p>\n";
+}
+include("kmfooter.php");
+?>

--- a/kmtool/www/kmtool/kmsendemail.php
+++ b/kmtool/www/kmtool/kmsendemail.php
@@ -170,7 +170,6 @@ if ($db_result) {
   $db_id = $db_result['id'];
   $confirm_url = create_email_confirm_link($db_id, $nonce);
   if (send_user_confirmation_email($email, $confirm_url)) {
-    
     print "<h2>Email Address Asserted</h2>\n";
     print "<p>\n";
     print "A confirmation email has been sent to $email.</p>";
@@ -181,7 +180,7 @@ if ($db_result) {
     print "</p>\n";
   } else {
     // Failed to queue email
-    
+
     // Notify admins  / put in log
     error_log("Failed to send self asserted email confirmation email to " . $email . " for eppn " . $eppn);
 
@@ -195,7 +194,7 @@ if ($db_result) {
 } else {
   // Notify admins  / put in log
   error_log("Failed to insert into DB self asserted email confirmation request for " . $email . " and eppn " . $eppn);
-  
+
   // Produce the result page
   print "<h2>Address Assertion failed</h2>";
   print "<p> We are sorry, your email address assertion failed. ";


### PR DESCRIPTION
Self asserting your email address when your IdP does not supply one (but does supply EPPN) used to require operators to read an email. Instead, make this self service for experimenters.

Adding new table `km_confirm_email` to hold the nonce and email for a given eppn.

`kmnoemail.php` will clear entries from that table that are 7 days old. If you shouldn't be here (no eppn, got email, already asserted email) it redirects. It reads any partially asserted email address to pre fill out a form asking for an email address, which goes to....
New page: `kmsendemail.php` redirects if you're in the wrong place, sends you back to kmnoemail on a bad email address. Otherwise it replaces any existing entry in km_no_email, and sends the experimenter email to confirm their address (BCCing admins), and telling them to look for this email.
The email points them to new page `kmconfirmemail.php`.
That page redirects if you're in the wrong place, complains if this is a bad link (id/nonce/eppn triple). Otherwise it puts the email/eppn in km_asserted_attributes and removes the entry from km_confirm_email.

To make this work properly, added a bunch to the KM CSS and a line to `kmheader` (to properly show/validate the form, and to support `tool-showmessage` and its clear button).

Note that this change adds a new DB table; run `kmtool/db/postgresql/update-2.sql` to create this table on an existing portal.

Note that this change makes the chapi script `geni-assert-email` OBE.

Fixes #1673 
