### PR TITLE
Tkt1694: Check for valid image names in createimage, handle errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ## Changes
 
+* Check that image name to `Create Image` is alphanumeric, and
+  handle error returns from Omni on createimage.
+  ([#1694](https://github.com/GENI-NSF/geni-portal/issues/1694))
 * Fix adding global node to work on first page load
   ([#1718](https://github.com/GENI-NSF/geni-portal/issues/1718))
 * Fix Jacks hang when displayed in expanded view

--- a/portal/www/portal/createimage.php
+++ b/portal/www/portal/createimage.php
@@ -109,6 +109,7 @@ function do_create_image()
   image_name = ($('#create_image_name'))[0].value;
   image_public = ($('#create_image_public'))[0].checked;
   var div = $('#create_image_text_div');
+  div.empty();
   div.append($('<i>Creating image....</i>'));
   console.log("do_image_create " + image_name + " " + image_public);
   $.getJSON('image_operations.php',

--- a/portal/www/portal/createimage.php
+++ b/portal/www/portal/createimage.php
@@ -148,9 +148,10 @@ print "<h1>Create Image on Selected Node</h1>";
 
 print "<form method='POST' >";
 
-print "<table><tr><th>Image Name</th><td><input type='text' id='create_image_name' size'30'></td></tr>";
+print "<table><tr><th>Image Name</th><td><input type='text' id='create_image_name' size'30' required></td></tr>";
 print "<tr><th>Image Visibility</th><td>Public <input type='radio' checked='checked' name='create_image_visibility' id='create_image_public'> Private <input type='radio' name='create_image_visibility' id='create_image_private'></td></tr>";
 print "</table>";
+print "<p>Note: Image name must be non-empty and alphanumeric only.</p>\n";
 
 print "<input type='button' value='Create' onclick='do_create_image()' />";
 print "<input type='button' value='Back' onclick='history.back(-1)'/>";

--- a/portal/www/portal/createimage.php
+++ b/portal/www/portal/createimage.php
@@ -127,7 +127,12 @@ function do_create_image()
 		var image_id = rt.value[1];
 		add_image_info(image_urn, image_id);
 	      } else {
-		add_image_error(rt.output);
+		// On failure the return may be a string, so no 'output'
+		if (typeof(rt.output) !== 'undefined') {
+		  add_image_error(rt.output);
+		} else {
+		  add_image_error(rt);
+		}
 	      }
 	    })
 	    .fail(function (xhr, ts, et) {

--- a/portal/www/portal/image_operations.php
+++ b/portal/www/portal/image_operations.php
@@ -131,7 +131,7 @@ function perform_list_operation()
     }
     $isAlpha = preg_match("/^[0-9a-zA-Z]+$/", $image_name, $matches);
     if ($isAlpha != 1) {
-      error_log("Invalid image name to createimage: " . $image_name)
+      error_log("Invalid image name to createimage: '" . $image_name . "'");
       return error_response("Image name must be alphanumeric", RESPONSE_ERROR::ARGS);
     }
     $response = invoke_omni_function($am_url, $user, 
@@ -141,6 +141,7 @@ function perform_list_operation()
 					 $_GET['public'],
 					 '--project', $_GET['project_name'],
 					 '-u', $_GET['sliver_id']));
+    // Return may be a string on error
     if (is_array($response)) {
       $response = $response[1];
     }
@@ -167,7 +168,7 @@ function perform_list_operation()
     if ($response) {
       $output .= ": " . $response;
     }
-    $output .= "<br/>Please <a href='contact-us.php'>contact us</a> for help.";
+    $output .= "<br/><br/>Please <a href='contact-us.php'>contact us</a> for help.";
   }
   return $output;
 }


### PR DESCRIPTION
`createimage` requires an alphanumeric imagename. Omni checks this; the portal should first.

Additionally, on error Omni can return just a string - no tuple. `image_operations` fails to account for this, and `createimage` too.

Tell the user to use an alphanumeric image name, check that they do so, and handle error returns from Omni.

Fixes issue #1694 