### PR TITLE
Issue #1724: handle theoretical errors doing restartsliver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 
 ## Changes
 
+* Handle error / string return from `restart_sliver` in
+  `restartsliver.php`.
+  ([#1724](https://github.com/GENI-NSF/geni-portal/issues/1724))
 * Show specific shared attributes on OpenID trust page.
   ([#1697](https://github.com/GENI-NSF/geni-portal/issues/1697))
 * Fix adding global node to work on first page load

--- a/lib/php/am_client.php
+++ b/lib/php/am_client.php
@@ -969,14 +969,12 @@ function delete_sliver($am_url, $user, $slice_credential, $slice_urn, $slice_id 
 
 function restart_sliver($am_url, $user, $slice_credential, $slice_urn, $slice_id)
 {
-  if (! isset($am_url) || is_null($am_url) ){
-    if (!(is_array($am_url) || $am_url != '')) {
-      error_log("am_client cannot invoke Omni without an AM URL");
-      return("Missing AM URL");
-    }
+  if (! $am_url ) {
+    error_log("am_client cannot invoke Omni without an AM URL");
+    return("Missing AM URL");
   }
 
-  if (! isset($slice_credential) || is_null($slice_credential) || $slice_credential == '') {
+  if (! $slice_credential) {
     error_log("am_client cannot act on a slice without a credential");
     return("Missing slice credential");
   }
@@ -992,7 +990,7 @@ function restart_sliver($am_url, $user, $slice_credential, $slice_urn, $slice_id
 		'performoperationalaction',
 		$slice_urn,
 		'geni_restart');
-  // Note that this AM no longer has resources
+
   $output = invoke_omni_function($am_url, $user, $args, array(), 0, 0, 
 				 false, NULL, $api_version="3");
   unlink($slice_credential_filename);

--- a/portal/www/portal/restartsliver.php
+++ b/portal/www/portal/restartsliver.php
@@ -135,9 +135,15 @@ if (! isset($ams) || is_null($ams) || count($ams) <= 0) {
   //error_log("Restart_Sliver output = " . $retVal);
 }
 
-$return_urls = array_keys($retVal[1]);
-$return_url = $return_urls[0];
-$success = $retVal[1][$return_url]['code']['geni_code'] == 0;
+$retMsg = $retVal;
+$success = False;
+if (is_array($retVal)) {
+  // Theoretically restart_sliver could return a string error message on failure
+  $return_urls = array_keys($retVal[1]);
+  $return_url = $return_urls[0];
+  $success = $retVal[1][$return_url]['code']['geni_code'] == 0;
+  $retMsg = $retVal[0];
+}
 
 if ($success) {
   $log_url = get_first_service_of_type(SR_SERVICE_TYPE::LOGGING_SERVICE);
@@ -155,6 +161,8 @@ if ($success) {
 	      "Restarted resources from slice " . $slice_name,
 	      $log_attributes);
   }
+} else {
+  error_log("Failed to restart sliver: " . $retMsg);
 }
 
 ?>


### PR DESCRIPTION
Look for a non array (string) return from `restart_sliver` (really `invoke_omni_operation`) and treat that as an error (log it), rather than blindly trying to treat the return as an array.

Omni could theoretically produce such a return, though I don't see a code path here that would cause it.

Fixes #1724 