### PR TITLE
Fix quotes inside examples in texinfo document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Fix quotes inside examples in texinfo document
+  ([#1731](https://github.com/GENI-NSF/geni-portal/issues/1731))
 
 ## Installation Notes
 

--- a/doc/geni-portal.texi
+++ b/doc/geni-portal.texi
@@ -9,6 +9,10 @@
 @c combine the program index into the concept index
 @syncodeindex pg cp
 
+@c Use ascii quotes in @code, @example, and similar blocks
+@set codequoteundirected on
+@set codequotebacktick on
+
 @copying
 Copyright @copyright{} 2015-2016 Raytheon BBN Technologies
 
@@ -581,7 +585,6 @@ authority=origin.example.com
 @emph{This step is only necessary if the new server will use a
 different domain name than the original server.}
 @c render the single quotes properly for copy/paste
-@set codequoteundirected on
 @example
 update service_registry
   set service_url = replace(service_url,
@@ -589,7 +592,6 @@ update service_registry
                             'dest.example.com')
   where service_url like '%origin.example.com%';
 @end example
-@set codequoteundirected off
 
 @section Configure host: DNS update
 This step is only necessary if the new, or ``target'' server will use the same


### PR DESCRIPTION
Avoid confusion with stylized quotes in code and shell examples by forcing ascii quotes.