### PR TITLE
Rework the 'Join A Project' page for better privacy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changes
 
+* Rework the 'Join A Project' page for better privacy
+  ([#1743](https://github.com/GENI-NSF/geni-portal/issues/1743))
 * Remove cc to admins on self-asserted email address
   ([#1744](https://github.com/GENI-NSF/geni-portal/issues/1744))
 

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -388,6 +388,7 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/jacks-editor-app.js
 %{webdir}/secure/jacks-lib.js
 %{webdir}/secure/jfed.php
+%{webdir}/secure/join-project.js
 %{webdir}/secure/join-project.php
 %{webdir}/secure/join-this-project.php
 %{webdir}/secure/km_utils.php
@@ -400,6 +401,7 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/kmsendemail.php
 %{webdir}/secure/kmconfirmemail.php
 %{webdir}/secure/listresources.php
+%{webdir}/secure/lookup-project.php
 %{webdir}/secure/listresources_plain.php
 %{webdir}/secure/loadcert.js
 %{webdir}/secure/loadcert.php

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -388,6 +388,7 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/jacks-editor-app.js
 %{webdir}/secure/jacks-lib.js
 %{webdir}/secure/jfed.php
+%{webdir}/secure/join-project.css
 %{webdir}/secure/join-project.js
 %{webdir}/secure/join-project.php
 %{webdir}/secure/join-this-project.php

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -132,6 +132,7 @@ dist_svcweb_DATA = \
 	www/portal/jacks-editor-app-expanded.php \
 	www/portal/jacks-lib.js \
 	www/portal/jfed.php \
+	www/portal/join-project.css \
 	www/portal/join-project.js \
 	www/portal/join-project.php \
 	www/portal/join-this-project.php \

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -132,9 +132,11 @@ dist_svcweb_DATA = \
 	www/portal/jacks-editor-app-expanded.php \
 	www/portal/jacks-lib.js \
 	www/portal/jfed.php \
+	www/portal/join-project.js \
 	www/portal/join-project.php \
 	www/portal/join-this-project.php \
 	www/portal/listresources.php \
+	www/portal/lookup-project.php \
 	www/portal/listresources_plain.php \
 	www/portal/maintenance_redirect_page.php \
 	www/portal/modify.php \

--- a/portal/www/portal/join-project.css
+++ b/portal/www/portal/join-project.css
@@ -1,0 +1,9 @@
+#finderror {
+  color: red;
+}
+
+#findform {
+  margin-top: 30px;
+  margin-left: 20px;
+  margin-bottom: 50px;
+}

--- a/portal/www/portal/join-project.js
+++ b/portal/www/portal/join-project.js
@@ -1,15 +1,23 @@
+function show_lookup_error(msg) {
+  $('#finderror').append(msg);
+  $('#findname').select();
+}
+
 function handle_lookup(data) {
   if (data.code == 0) {
     // Project lookup was successful
     // redirect to join-this-project.php?project_id=id
     // get project from value field, and project_id from that
     var project = data.value
-    var url = "join-this-project.php?project_id=" + project.project_id;
-    window.location.href = url;
+    if (project.expired) {
+      show_lookup_error("Project " + project.project_name + " has expired.");
+    } else {
+      var url = "join-this-project.php?project_id=" + project.project_id;
+      window.location.href = url;
+    }
   } else {
     // Handle error case
-    $('#finderror').append(data.output);
-    $('#findname').select();
+    show_lookup_error(data.output);
   }
 }
 

--- a/portal/www/portal/join-project.js
+++ b/portal/www/portal/join-project.js
@@ -4,11 +4,11 @@ function show_lookup_error(msg) {
 }
 
 function handle_lookup(data) {
-  if (data.code == 0) {
+  if (data.code === 0) {
     // Project lookup was successful
     // redirect to join-this-project.php?project_id=id
     // get project from value field, and project_id from that
-    var project = data.value
+    var project = data.value;
     if (project.expired) {
       show_lookup_error("Project " + project.project_name + " has expired.");
     } else {
@@ -29,8 +29,8 @@ function handle_error(jqXHR, textStatus, errorThrown) {
 function lookup_project(project_name) {
   // Clear out any previous errors
   $('#finderror').empty();
-  var lookup_url = "/secure/lookup-project.php"
-  var data = {name: project_name}
+  var lookup_url = "/secure/lookup-project.php";
+  var data = {name: project_name};
   $.post(lookup_url, data, handle_lookup, 'json').fail(handle_error);
 }
 

--- a/portal/www/portal/join-project.js
+++ b/portal/www/portal/join-project.js
@@ -1,5 +1,5 @@
 function show_lookup_error(msg) {
-  $('#finderror').append(msg);
+  $('#finderror').html(msg);
   $('#findname').select();
 }
 
@@ -28,7 +28,7 @@ function handle_error(jqXHR, textStatus, errorThrown) {
 
 function lookup_project(project_name) {
   // Clear out any previous errors
-  $('#finderror').empty();
+  $('#finderror').html('&nbsp;');
   var lookup_url = "/secure/lookup-project.php";
   var data = {name: project_name};
   $.post(lookup_url, data, handle_lookup, 'json').fail(handle_error);
@@ -44,4 +44,5 @@ $(document).ready( function () {
   /* datatables.net (for sortable/searchable tables) */
   $('#projects').DataTable({paging: false});
   $('#findbtn').click(do_lookup_project);
+  $('<link rel="stylesheet" href="join-project.css"></link>').appendTo(document.head);
 } );

--- a/portal/www/portal/join-project.js
+++ b/portal/www/portal/join-project.js
@@ -1,20 +1,21 @@
 function handle_lookup(data) {
   if (data.code == 0) {
     // Project lookup was successful
-    // get project id from data
     // redirect to join-this-project.php?project_id=id
+    // get project from value field, and project_id from that
     var project = data.value
-    console.log(project.project_id);
+    var url = "join-this-project.php?project_id=" + project.project_id;
+    window.location.href = url;
   } else {
     // Handle error case
-    console.log("fail")
     $('#finderror').append(data.output);
     $('#findname').select();
   }
 }
+
 function handle_error(jqXHR, textStatus, errorThrown) {
-  console.log("error");
   // An unknown error has occurred. Pop up a dialog box.
+  alert("An unknown error occurred.");
 }
 
 function lookup_project(project_name) {

--- a/portal/www/portal/join-project.js
+++ b/portal/www/portal/join-project.js
@@ -1,0 +1,38 @@
+function handle_lookup(data) {
+  if (data.code == 0) {
+    // Project lookup was successful
+    // get project id from data
+    // redirect to join-this-project.php?project_id=id
+    var project = data.value
+    console.log(project.project_id);
+  } else {
+    // Handle error case
+    console.log("fail")
+    $('#finderror').append(data.output);
+    $('#findname').select();
+  }
+}
+function handle_error(jqXHR, textStatus, errorThrown) {
+  console.log("error");
+  // An unknown error has occurred. Pop up a dialog box.
+}
+
+function lookup_project(project_name) {
+  // Clear out any previous errors
+  $('#finderror').empty();
+  var lookup_url = "/secure/lookup-project.php"
+  var data = {name: project_name}
+  $.post(lookup_url, data, handle_lookup, 'json').fail(handle_error);
+}
+
+function do_lookup_project(event) {
+        event.preventDefault();
+        lookup_project($('#findname').val());
+}
+
+
+$(document).ready( function () {
+  /* datatables.net (for sortable/searchable tables) */
+  $('#projects').DataTable({paging: false});
+  $('#findbtn').click(do_lookup_project);
+} );

--- a/portal/www/portal/join-project.php
+++ b/portal/www/portal/join-project.php
@@ -69,23 +69,28 @@ echo '<script src="join-project.js"></script>';
 // Get list of all projects you are not in or already requested to join
 // Produce a table of projects you could join
 // project name, project lead, project description, Button to Join
+?>
+<h1>Join a Project</h1>
 
-print "<h1>Join a Project</h1>\n";
+<p>
+You must belong to a GENI Project in order to create or join slices
+and run experiments.  On this page, you can request to join a project.
+</p>
 
-print "<p>All GENI actions must be taken in the context of a
-  project. On this page, you can request to join a project.</p>";
+<p><b>
+You should request to join a project only if the project lead knows you,
+as he or she is taking responsibility for your actions. Attempts to join
+projects whose leads you do not know may result in the revocation of your
+GENI account.
+</b></p>
 
-print "<p><b>You should only request to join a project if the project
- lead knows you, as the  project lead is taking responsibility for
- your actions. Please do not try to join arbitrary projects. Abuse of
- this functionality may result in revocation
- of your GENI account.</b></p>";
+<p>
+After the project lead makes a decision about your request, you will be
+notified by email. Once you are a member of a project, you can create or
+request to join a slice.
+</p>
 
-print "<p>Once the project lead makes a decision about your request you
- will be notified through email. Once you are a member of a project,
- you can create a slice, or request to join an existing slice.";
-
-
+<?php
 // FIXME: Replace these 2 calls with 1 call that gets the project details the first time
 
 if (! isset($pids) || is_null($pids) || count($pids) < 1) {

--- a/portal/www/portal/join-project.php
+++ b/portal/www/portal/join-project.php
@@ -62,6 +62,9 @@ show_header('GENI Portal: Projects');
 
 include("tool-breadcrumbs.php");
 
+// Load this page's javascript
+echo '<script src="join-project.js"></script>';
+
 // Join a project
 // Get list of all projects you are not in or already requested to join
 // Produce a table of projects you could join
@@ -81,6 +84,7 @@ print "<p>Once the project lead makes a decision about your request you
  will be notified through email. Once you are a member of a project,
  you can create a slice, or request to join an existing slice.";
 
+
 // FIXME: Replace these 2 calls with 1 call that gets the project details the first time
 
 if (! isset($pids) || is_null($pids) || count($pids) < 1) {
@@ -95,14 +99,16 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
   print "<p><i>Please do not try to join arbitrary projects. Abuse of
    this functionality may result in revocation of your GENI account.
    </i></p>";
+?>
 
-  /* datatables.net (for sortable/searchable tables) */
-  echo '<script type="text/javascript">';
-  echo '$(document).ready( function () {';
-  echo '  $(\'#projects\').DataTable({paging: false});';
-  echo '} );';
-  echo '</script>';
+<form>
+<input id="findname" type="text"/>
+<div id="finderror"></div>
+<br/>
+<button id="findbtn" type="submit">Join</button>
+</form>
 
+<?php
   print "<table id=\"projects\" class=\"display\">\n";
   print "<thead>\n";
   print "<tr><th>Project</th><th>Purpose</th><th>Project Lead</th><th>Join</th></tr>\n";

--- a/portal/www/portal/join-project.php
+++ b/portal/www/portal/join-project.php
@@ -33,8 +33,8 @@ require_once("cs_constants.php");
 
 function project_name_compare($p1, $p2)
 {
-  $pn1 = $p1[PA_PROJECT_TABLE_FIELDNAME::PROJECT_NAME]; 
-  $pn2 = $p2[PA_PROJECT_TABLE_FIELDNAME::PROJECT_NAME]; 
+  $pn1 = $p1[PA_PROJECT_TABLE_FIELDNAME::PROJECT_NAME];
+  $pn2 = $p2[PA_PROJECT_TABLE_FIELDNAME::PROJECT_NAME];
   if ($pn1 == $pn2) {
     return 0;
   } else {
@@ -95,14 +95,14 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
   print "<p><i>Please do not try to join arbitrary projects. Abuse of
    this functionality may result in revocation of your GENI account.
    </i></p>";
-   
+
   /* datatables.net (for sortable/searchable tables) */
   echo '<script type="text/javascript">';
   echo '$(document).ready( function () {';
   echo '  $(\'#projects\').DataTable({paging: false});';
   echo '} );';
   echo '</script>';
-   
+
   print "<table id=\"projects\" class=\"display\">\n";
   print "<thead>\n";
   print "<tr><th>Project</th><th>Purpose</th><th>Project Lead</th><th>Join</th></tr>\n";
@@ -112,8 +112,8 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
   //  error_log("PROJ_DETAILS = " . print_r($project_details, true));
 
   $ma_url = get_first_service_of_type(SR_SERVICE_TYPE::MEMBER_AUTHORITY);
-  $member_names = lookup_member_names_for_rows($ma_url, $user, 
-					       $project_details, 
+  $member_names = lookup_member_names_for_rows($ma_url, $user,
+					       $project_details,
 					       PA_PROJECT_TABLE_FIELDNAME::LEAD_ID);
   //  error_log("MEMBER_DETAILS = " . print_r($member_names, true));
 

--- a/portal/www/portal/join-project.php
+++ b/portal/www/portal/join-project.php
@@ -77,7 +77,8 @@ print "<p>All GENI actions must be taken in the context of a
 
 print "<p><b>You should only request to join a project if the project
  lead knows you, as the  project lead is taking responsibility for
- your actions. Abuse of this functionality may result in revocation
+ your actions. Please do not try to join arbitrary projects. Abuse of
+ this functionality may result in revocation
  of your GENI account.</b></p>";
 
 print "<p>Once the project lead makes a decision about your request you
@@ -95,20 +96,18 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
 
 } else {
 
-  print "<h2>Select a project to join</h2>\n";
-  print "<p><i>Please do not try to join arbitrary projects. Abuse of
-   this functionality may result in revocation of your GENI account.
-   </i></p>";
 ?>
 
+<section id="findform">
 <form>
-<input id="findname" type="text"/>
-<div id="finderror"></div>
-<br/>
+Enter a project name: <input id="findname" type="text"/>
 <button id="findbtn" type="submit">Join</button>
+<div id="finderror">&nbsp;</div>
+</section>
 </form>
 
 <?php
+  print "<h2>GENI Projects</h2>\n";
   print "<table id=\"projects\" class=\"display\">\n";
   print "<thead>\n";
   print "<tr><th>Project Purpose</th><th>Project Lead</th></tr>\n";

--- a/portal/www/portal/join-project.php
+++ b/portal/www/portal/join-project.php
@@ -111,8 +111,7 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
 <?php
   print "<table id=\"projects\" class=\"display\">\n";
   print "<thead>\n";
-  print "<tr><th>Project</th><th>Purpose</th><th>Project Lead</th><th>Join</th></tr>\n";
-  $jointhis_url = "join-this-project.php?project_id=";
+  print "<tr><th>Project Purpose</th><th>Project Lead</th></tr>\n";
   $project_details = lookup_project_details($sa_url, $user, $pids);
   usort($project_details, "project_name_compare");
   //  error_log("PROJ_DETAILS = " . print_r($project_details, true));
@@ -129,16 +128,11 @@ if (! isset($pids) || is_null($pids) || count($pids) < 1) {
     //    $project = lookup_project($sa_url, $user, $project_id);
     $expired = $project[PA_PROJECT_TABLE_FIELDNAME::EXPIRED];
     if (convert_boolean($expired)) continue;
-    print "<tr><td>";
-    print $project[PA_PROJECT_TABLE_FIELDNAME::PROJECT_NAME];
-    print "</td><td>";
-    print $project[PA_PROJECT_TABLE_FIELDNAME::PROJECT_PURPOSE];
-    print "</td><td>";
+    $purpose = $project[PA_PROJECT_TABLE_FIELDNAME::PROJECT_PURPOSE];
+    if (! $purpose) continue;
     $lead_id = $project[PA_PROJECT_TABLE_FIELDNAME::LEAD_ID];
     $leadname = $member_names[$lead_id];
-    print $leadname;
-    $project_id = $project[PA_PROJECT_TABLE_FIELDNAME::PROJECT_ID];
-    print "</td><td><button onClick=\"window.location='" . $jointhis_url . $project_id . "'\"><b>Join</b></button></td></tr>\n";
+    print "<tr><td>$purpose</td><td>$leadname</td></tr>\n";
   }
   print "</tbody>\n";
   print "</table>\n";

--- a/portal/www/portal/join-this-project.php
+++ b/portal/www/portal/join-this-project.php
@@ -124,7 +124,7 @@ if (isset($message) && ! is_null($message) && (!isset($error) || is_null($error)
 https://$hostname/secure/handle-project-request.php?project_id=$project_id&member_id=" . $user->account_id . "&request_id=$request_id
 
 Remember that when you approve this request, you agree to take
-responsibility for my use of GENI resources within the project. 
+responsibility for my use of GENI resources within the project.
 You should not approve unsolicited requests to join your project.
 
 Thank you,\n" . $user->prettyName() . "\n";
@@ -149,7 +149,7 @@ Thank you,\n" . $user->prettyName() . "\n";
   $name = $user->prettyName();
   if (isset($log_url)) {
     log_event($log_url, Portal::getInstance(),
-	      "$name requested to join project $project_name", 
+	      "$name requested to join project $project_name",
 	      $attributes);
   }
 
@@ -163,11 +163,11 @@ Thank you,\n" . $user->prettyName() . "\n";
     $cc = ""; // FIXME: Include portal-dev-admin?
   }
   $headers = "Reply-To: $email" . "\r\n" . $cc . "From: \"$name (via the GENI Portal)\" <www-data@gpolab.bbn.com>\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit";
-  
+
   mail($lead->prettyEmailAddress(),
        "Request to Join GENI project $project_name",
        $message, $headers);
-       
+
   // We could supply the -f arg to make bounces go back to this portal user,
   // but we probably want to know if the lead's email address is bouncing.
        //       "-f $email");
@@ -176,7 +176,7 @@ Thank you,\n" . $user->prettyName() . "\n";
   show_header('GENI Portal: Projects');
   include("tool-breadcrumbs.php");
   print "<h1>Join Project <i>$project_name</i></h1>\n";
-  
+
   print "<p>\n";
   print "<b>Sent</b> request to join GENI project <b>$project_name</b> to <b>$leadname</b>.</p>\n";
   $lines = explode("\r\n", $message);
@@ -187,22 +187,33 @@ Thank you,\n" . $user->prettyName() . "\n";
   print "</pre>";
   include("footer.php");
   exit();
-  
+
 }
 
 show_header('GENI Portal: Projects');
 include("tool-breadcrumbs.php");
-print "<h1>Join Project <i>$project_name</i></h1>\n";
 
-print "<p>All GENI actions must be taken in the context of a project. \n";
-print "On this page, you can request to join the project <i>$project_name</i>.</p> " 
-  . "<p>The project lead ($leadname) will be sent an email, to approve or deny your request. \n";
-print "That email will have a link to a page where the project lead can act on your request. \n";
-print "When the project lead ($leadname) acts on your request, you will get an email " .
-"notifying you whether your request was approved.\n";
-print "Once approved, you can create a slice, or request to join an existing slice.</p>\n";
-print "<p>When you ask to join a project, you are requesting that the project lead take responsibility for your use of GENI resources within that project. You should only request to join a project if the project lead knows who you are and wishes for you to join his or her project.</p>\n";
+?>
 
+<h1>Join Project <i><?php echo $project_name; ?></i></h1>
+
+<p>
+You are about to request to join the project
+<i><?php echo $project_name; ?></i> whose lead is
+<i><?php echo $leadname; ?></i>.
+You should continue with this request only if
+<?php echo $leadname; ?> knows you and would be willing to
+take responsibility for your use of GENI resources.
+</p>
+
+<p>
+When you send your join request, <?php echo $leadname; ?> will
+be sent an email with instructions to approve or deny
+your request. After your request is approved, you can create
+or join a slice in this project.
+</p>
+
+<?php
 //- Show info on the project, lead
 print "<h3>Project <i>$project_name</i> details:</h3>\n";
 print "<table>\n";

--- a/portal/www/portal/lookup-project.php
+++ b/portal/www/portal/lookup-project.php
@@ -1,0 +1,76 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2016 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+
+/* When a user wants to join a project they type in a project name.
+ * This script is invoked by AJAX and looks up the project by name,
+ * returning a JSON object for the project containing basic
+ * project information.
+ *
+ * If no project by the given name exists, an empty JSON object
+ * is returned.
+ */
+
+require_once("sr_client.php");
+require_once("sr_constants.php");
+require_once("pa_client.php");
+require_once("pa_constants.php");
+
+$user = geni_loadUser();
+
+// If not a known user, redirect to onboard.
+if (!isset($user)) {
+  // signal an HTTP user error
+}
+
+function result($c, $v, $o) {
+  return array("code" => $c,
+               "value" => $v,
+               "output" => $o);
+}
+
+// There should be a project name in the request
+if (! array_key_exists("name", $_REQUEST)) {
+    // No name argument, return empty JSON object.
+    // print json_encode($emptyObject);
+    $result = result(1, null, "No project name specified.");
+} else {
+    $project_name = $_REQUEST["name"];
+
+    // Look up the project by name at the slice authority
+    $sa_url = get_first_service_of_type(SR_SERVICE_TYPE::SLICE_AUTHORITY);
+    $signer = $user;
+    $project = lookup_project_by_name($sa_url, $signer, $project_name);
+
+    if (is_null($project)) {
+        // No project with the given name exists.
+        // Return empty JSON object.
+        // print json_encode($emptyObject);
+        $result = result(1, null, "Project $project_name not found.");
+    } else {
+        $result = result(0, $project, "");
+    }
+}
+
+print json_encode($result);
+?>


### PR DESCRIPTION
Remove the list of project names and require that a user enter a project name in order to submit a join request. List only project description and lead for projects that have a description.

Fix up the text on the join project and join-this-project pages to be clearer, more concise, and more descriptive.

Fixes #1743 
