### PR TITLE
Use GENI Monitoring for Jacks AM status

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   ([#1743](https://github.com/GENI-NSF/geni-portal/issues/1743))
 * Remove cc to admins on self-asserted email address
   ([#1744](https://github.com/GENI-NSF/geni-portal/issues/1744))
+* Use GENI Monitoring for Jacks AM status
+  ([#1747](https://github.com/GENI-NSF/geni-portal/issues/1747))
 * Change the Disk Image JSON URL for the Genidesktop
   ([#1748](https://github.com/GENI-NSF/geni-portal/issues/1748))
 

--- a/portal/www/portal/jacks-editor-app-expanded.php
+++ b/portal/www/portal/jacks-editor-app-expanded.php
@@ -25,6 +25,7 @@
 require_once("user.php");
 require_once("header.php");
 require_once("settings.php");
+require_once("aggstatus.php");
 
 // error_log("POST = " . print_r($_POST, true));
 
@@ -57,7 +58,7 @@ echo '<script src="/secure/slice-add-resources-jacks.js"></script>';
 include("jacks-editor-app.php");
 setup_jacks_editor_slice_context();
 
-$AM_STATUS_LOCATION = "/etc/geni-ch/am-status.json";
+$AM_STATUS_LOCATION = $AM_STATUS_MON_FILE;
 $am_status = array("fake_urn" => "fake_status");
 if (file_exists($AM_STATUS_LOCATION)) {
   $am_status = json_decode(file_get_contents($AM_STATUS_LOCATION));

--- a/portal/www/portal/slice-add-resources-jacks.php
+++ b/portal/www/portal/slice-add-resources-jacks.php
@@ -31,6 +31,7 @@ require_once("sa_constants.php");
 require_once("sa_client.php");
 require_once("settings.php");
 require_once 'geni_syslog.php';
+require_once("aggstatus.php");
 
 $current_rspec = "";
 if (array_key_exists('current_editor_rspec', $_POST)) {
@@ -119,7 +120,7 @@ $all_rspecs = fetchRSpecMetaData($user);
 include("jacks-editor-app.php");
 setup_jacks_editor_slice_context();
 
-$AM_STATUS_LOCATION = "/etc/geni-ch/am-status.json";
+$AM_STATUS_LOCATION = $AM_STATUS_MON_FILE;
 $am_status = array("fake_urn" => "fake_status");
 if (file_exists($AM_STATUS_LOCATION)) {
   $am_status = json_decode(file_get_contents($AM_STATUS_LOCATION));


### PR DESCRIPTION
Update the Jacks editor and Jacks expanded editor to use GENI
monitoring data for aggregate status. Stop using the GPO monitoring
for the Jacks aggregate status.

Fixes #1747
