### PR TITLE
Include VM-noTxt-centered in installation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Install Jacks icon file VM-noTxt-centered
+  ([#1756](https://github.com/GENI-NSF/geni-portal/issues/1756))
 
 ## Installation Notes
 

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -301,6 +301,7 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/images/Symbols-Tips-icon-clear.png
 %{webdir}/images/UseGENI.png
 %{webdir}/images/witest-logo-white.png
+%{webdir}/images/VM-noTxt-centered.svg
 %{webdir}/images/Xen-VM-noTxt-centered.svg
 %{webdir}/images/Xen-VM-noTxt.svg
 %{webdir}/images/Xen-VM.svg

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -233,6 +233,7 @@ dist_svcwebimages_DATA = \
 	www/images/staticmap.png \
 	www/images/Symbols-Tips-icon-clear.png \
 	www/images/UseGENI.png \
+	www/images/VM-noTxt-centered.svg \
 	www/images/Xen-VM-noTxt-centered.svg \
 	www/images/Xen-VM-noTxt.svg \
 	www/images/Xen-VM.svg


### PR DESCRIPTION
Add a missing icon file used by the Jacks editor

Fixes #1756 
