### PR TITLE
Set envelope sender to the portal's own email address

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Set envelope sender to the portal's own email address
+  ([#1774](https://github.com/GENI-NSF/geni-portal/issues/1774))
 
 ## Installation Notes
 

--- a/portal/www/portal/ask-for-project.php
+++ b/portal/www/portal/ask-for-project.php
@@ -122,7 +122,7 @@ if (isset($requestee) && ! is_null($requestee) && (!isset($error) || is_null($er
        "Please create me a GENI Project",
        $message,
        $headers,
-       "-f $email");
+       "-f $portal_from_email");
 
   // FIXME: Ticket #65: Put this as a request. Include the request ID in the email?
   // Then when the request is handled, can auto add the member who requested the project.

--- a/portal/www/portal/do-upload-project-members.php
+++ b/portal/www/portal/do-upload-project-members.php
@@ -124,7 +124,7 @@ foreach($selections as $email_name => $attribs) {
 
     mail($email, $email_subject, $email_text,
 	 $headers,
-	 "-f $userEmail");
+	 "-f $portal_from_email");
     $num_members_invited = $num_members_invited + 1;
   }
 }

--- a/portal/www/portal/invite-to-project.php
+++ b/portal/www/portal/invite-to-project.php
@@ -142,7 +142,7 @@ Thank you,\n" . $user->prettyName() . "\n";
        "Join my GENI project $project_name!",
        $message,
        $headers,
-       "-f $email"); // This tells sendmail directly to resend the envelope-sender, so the portal users gets bounces
+       "-f $portal_from_email");
 
   $attributes = get_attribute_for_context(CS_CONTEXT_TYPE::PROJECT, $project_id);
   $msg = "$name invited people to project $project_name: $to";


### PR DESCRIPTION
Stop trying to be clever with the envelope-sender. Set it to the
portal's own from address. If the experimenter's email is set as
the envelope sender, the email can trigger SPF errors and cause
the mail to go undelivered or bounce.

Fixes #1774 
