### PR TITLE
Use a placeholder ssh key in geni-sync-wireless

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changes
 
+* Use a placeholder ssh key in geni-sync-wireless
+  ([#1726](https://github.com/GENI-NSF/geni-portal/issues/1726))
 * Fix redirect on upload ssh key
   ([#1778](https://github.com/GENI-NSF/geni-portal/issues/1778))
 

--- a/bin/geni-sync-wireless
+++ b/bin/geni-sync-wireless
@@ -416,9 +416,13 @@ class WirelessProjectManager:
             if username == self._options.holdingpen_admin:
                 continue
             member_ssh_keys = member_info['ssh_keys']
-            if len(member_ssh_keys) == 0:
-                syslog("Skipping user with no ssh keys: %s" % username)
-                continue
+            # The LDAP server on the other end requires ssh keys. If a user
+            # does not have them, use an obvious fake tag so they will See
+            # it in their profile. This solution is courtesy of Ivan at
+            # WinLab.
+            if not member_ssh_keys:
+                syslog('User %s has no ssh keys, using placeholder.' % (username))
+                member_ssh_keys = ['missing GENI ssh key']
             orbit_username = self.to_orbit_name(username)
             self.ensure_wimax_username(member_id, member_info)
             if orbit_username not in self._orbit_users:


### PR DESCRIPTION
If a project lead has no ssh keys it disrupts the synchronization
with the wireless testbed(s). Users must have an ssh key. The old
solution of skipping these users causes the script to abort early
if a project lead lacks ssh keys.

After consultation with WinLab, we are using a placeholder ssh key
for users who do not have ssh keys in GENI. This allows the sync to
work and will make it obvious to users that something is amiss when
they look at their profile and see "missing GENI ssh key".

Fixes #1726 