### PR TITLE
Remove githash file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-bin/geni-ch-githash
-
 # temporary/autosave editor files
 \#*#
 .#*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   ([#1726](https://github.com/GENI-NSF/geni-portal/issues/1726))
 * Fix redirect on upload ssh key
   ([#1778](https://github.com/GENI-NSF/geni-portal/issues/1778))
+* Remove githash file
+  ([#1781](https://github.com/GENI-NSF/geni-portal/issues/1781))
 
 ## Installation Notes
 

--- a/Makefile.sync
+++ b/Makefile.sync
@@ -19,23 +19,20 @@ SRC_DIR = ../$(notdir $(CURDIR))
 default:
 	echo "Choose a specific sync target."
 
-bin/geni-ch-githash: .git
-	git rev-parse HEAD > bin/geni-ch-githash
-
-syncb: bin/geni-ch-githash
+syncb:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) bigslide.gpolab.bbn.com:
 
-syncd: bin/geni-ch-githash
+syncd:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) dagoola.gpolab.bbn.com:
 
-syncm: bin/geni-ch-githash
+syncm:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) marilac.gpolab.bbn.com:
 
-synci: bin/geni-ch-githash
+synci:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) illyrica.gpolab.bbn.com:
 
-syncc: bin/geni-ch-githash
+syncc:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) cascade.gpolab.bbn.com:
 
-syncn: bin/geni-ch-githash
+syncn:
 	$(RSYNC) $(RSYNC_ARGS) $(SRC_DIR) nye.gpolab.bbn.com:

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -31,10 +31,6 @@ dist_bin_SCRIPTS = \
 bin_SCRIPTS = \
 	geni-get-ad-rspecs
 
-if INSTALL_GITHASH
-pkgsysconf_DATA = geni-ch-githash
-endif
-
 # GPO Lab
 # Install in /usr/local/lib, not /usr/lib
 PYFILES = portal_utils/__init__.py portal_utils/orbit_interface.py

--- a/configure.ac
+++ b/configure.ac
@@ -57,8 +57,6 @@ AC_ARG_ENABLE([gpo_lab],
 esac],[gpo_lab=false])
 AM_CONDITIONAL([GPO_LAB], [test x$gpo_lab = xtrue])
 
-AM_CONDITIONAL(INSTALL_GITHASH, [test -f bin/geni-ch-githash])
-
 AC_CONFIG_FILES([Makefile etc/Makefile bin/Makefile])
 AC_CONFIG_FILES([sr/Makefile lib/Makefile])
 AC_CONFIG_FILES([kmtool/Makefile portal/Makefile openid/Makefile])


### PR DESCRIPTION
Remove the githash file, a peculiarity of the GPO Lab and manual
installations. It is no longer necessary and serves no purpose for
package-based (i.e. RPM) installations.

Fixes #1781 