### PR TITLE
Support migrating accounts from GPO IdP to NCSA IdP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,23 @@
 
 ## Changes
 
-* None
+* Support migrating accounts from GPO IdP to NCSA IdP
+  ([#1786](https://github.com/GENI-NSF/geni-portal/issues/1786))
 
 ## Installation Notes
 
-* None
+* In order to enable the account transfer functionality, add the
+  following new settings to /etc/geni-ch/settings.php. Adjust the
+  values to suit the environment.
+
+  ```
+  /* Username for IdP admin pages */
+  $idp_user = "scott";
+  /* Password for IdP admin pages */
+  $idp_pass = "tiger";
+  /* IdP host */
+  $idp_host = "idp.example.com";
+  ```
 
 # [Release 3.22](https://github.com/GENI-NSF/geni-portal/milestones/3.22)
 

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -463,11 +463,14 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/tool-omniconfig.php
 %{webdir}/secure/tool-slices.js
 %{webdir}/secure/tools-user.js
+%{webdir}/secure/transfer.js
+%{webdir}/secure/transfer.php
 %{webdir}/secure/updatekeys.js
 %{webdir}/secure/updatekeys.php
 %{webdir}/secure/upload-file.php
 %{webdir}/secure/upload-project-members.php
 %{webdir}/secure/uploadsshkey.php
+%{webdir}/secure/verifyuser.php
 %{webdir}/secure/wimax-enable.php
 %{webdir}/secure/wireless_operations.php
 %{webdir}/secure/wireless_redirect.php

--- a/geni-portal.spec
+++ b/geni-portal.spec
@@ -354,6 +354,7 @@ rm -rf $RPM_BUILD_ROOT
 %{webdir}/secure/do-user-admin.php
 %{webdir}/secure/do-user-search.php
 %{webdir}/secure/dologout.php
+%{webdir}/secure/dotransfer.php
 %{webdir}/secure/downloadkeycert.php
 %{webdir}/secure/downloadomnibundle.php
 %{webdir}/secure/downloadputtykey.php

--- a/lib/php/ma_client.php
+++ b/lib/php/ma_client.php
@@ -951,4 +951,13 @@ function get_member_urn($ma_url, $signer, $id) {
   }
 }
 
+function ma_swap_identities($ma_url, $signer, $source_urn, $dest_urn) {
+    $client = XMLRPCClient::get_client($ma_url, $signer);
+    $options = array();
+    $options = array_merge($options, $client->options());
+    $r = $client->swap_identities($source_urn, $dest_urn, $client->creds(),
+                                  $options);
+    return $r;
+}
+
 ?>

--- a/lib/php/ma_client.php
+++ b/lib/php/ma_client.php
@@ -41,8 +41,8 @@ function add_member_attribute($ma_url, $signer, $member_id, $name, $value, $self
   global $member_by_attribute_cache;
   $member_urn = get_member_urn($ma_url, $signer, $member_id);
   $client = XMLRPCClient::get_client($ma_url, $signer);
-  $results = $client->add_member_attribute($member_urn, _portalkey_to_attkey($name), 
-					   $value, $self_asserted, $client->creds(), 
+  $results = $client->add_member_attribute($member_urn, _portalkey_to_attkey($name),
+					   $value, $self_asserted, $client->creds(),
 					   $client->options());
   // On success, remove from the attribute cache 'MEMBER_UID.' . $member_id
   if (array_key_exists('MEMBER_UID.' . $member_id, $member_by_attribute_cache)) {
@@ -51,7 +51,7 @@ function add_member_attribute($ma_url, $signer, $member_id, $name, $value, $self
   return $results;  // probably ignored
 }
 
-// Add a privilege to a member 
+// Add a privilege to a member
 // privilege is either OPERATOR or PROJECT_LEAD
 function add_member_privilege($ma_url, $signer, $member_id, $value)
 {
@@ -74,7 +74,7 @@ function remove_member_attribute($ma_url, $signer, $member_id, $name)
   global $member_by_attribute_cache;
   $member_urn = get_member_urn($ma_url, $signer, $member_id);
   $client = XMLRPCClient::get_client($ma_url, $signer);
-  $results = $client->remove_member_attribute($member_urn, _portalkey_to_attkey($name), 
+  $results = $client->remove_member_attribute($member_urn, _portalkey_to_attkey($name),
 					   $client->creds(),
                                               $client->options());
   // On success, remove from the attribute cache 'MEMBER_UID.' . $member_id
@@ -84,7 +84,7 @@ function remove_member_attribute($ma_url, $signer, $member_id, $name)
   return $results;  // probably ignored
 }
 
-function disable_user($ma_url, $signer, $member_urn) 
+function disable_user($ma_url, $signer, $member_urn)
 {
   $client = XMLRPCClient::get_client($ma_url, $signer);
   $results = $client->enable_user($member_urn, false, $client->creds(), $client->options());
@@ -149,7 +149,7 @@ function lookup_public_ssh_keys($ma_url, $signer, $member_id)
   $ssh_keys[] = $mapped_array[0];
     }
   }
-  
+
   return $ssh_keys;
 }
 
@@ -181,7 +181,7 @@ function lookup_private_ssh_keys($ma_url, $signer, $member_id)
       $ssh_keys[] = $mapped_array[0];
     }
   }
-  
+
   return $ssh_keys;
 }
 
@@ -253,7 +253,7 @@ function lookup_keys_and_certs($ma_url, $signer, $member_uuid)
     $puboptions = array('match'=> array('MEMBER_UID'=>$member_uuid),
 			'filter'=>array('_GENI_MEMBER_INSIDE_CERTIFICATE'));
     $puboptions = array_merge($puboptions, $client->options());
-    $pubres = $client->lookup_public_member_info($client->creds(), 
+    $pubres = $client->lookup_public_member_info($client->creds(),
 						 $puboptions);
     if (sizeof($pubres)>0) {
       $certificate = NULL;
@@ -286,9 +286,9 @@ function ma_create_account($ma_url, $signer, $attrs, $self_asserted_attrs)
   $client = XMLRPCClient::get_client($ma_url, $signer);
   $results = $client->create_member($all_attrs, $client->creds(),
                                     $client->options());
-  
+
 //  error_log("MA_CREATE_ACCOUNT.results = " . print_r($results, true));
-  
+
   // return member_id
   return $results[0]['member_id'];
 }
@@ -334,7 +334,7 @@ function _portalkey_to_attkey($k) {
   } else {
     return $k;
   }
-}  
+}
 
 function _attkey_to_portalkey($k) {
   global $MEMBERALTKEYS;
@@ -351,7 +351,7 @@ class Member {
   function __construct($id=null) {
     $this->member_id = $id;
   }
-  
+
   function init_from_record($attrs) {
     foreach ($attrs as $k => $v) {
       $this->{$k} = $v;
@@ -386,7 +386,7 @@ function ma_lookup_member_by_eppn($ma_url, $signer, $eppn)
   $options = array('match'=>array('_GENI_MEMBER_EPPN' => $eppn),
 		   'filter'=> array_merge(
 			       array('MEMBER_UID',
-				     '_GENI_MEMBER_INSIDE_PRIVATE_KEY', 
+				     '_GENI_MEMBER_INSIDE_PRIVATE_KEY',
 				     '_GENI_MEMBER_INSIDE_CERTIFICATE'),
 			       array_merge($DETAILS_PUBLIC,
 					   $DETAILS_IDENTIFYING)));
@@ -431,7 +431,7 @@ function ma_lookup_members_by_identifying($ma_url, $signer,
   $options = array_merge($options, $client->options());
   $pubres = $client->lookup_public_member_info($client->creds(), $options);
   //  error_log( " PUBRES = " . print_r($pubres, true));
-  
+
   $ids = array();
   foreach ($pubres as $urn => $pubrow) {
     $uid = $pubrow['MEMBER_UID'];
@@ -493,7 +493,7 @@ function ma_authorize_client($ma_url, $signer, $member_id, $client_urn,
   return $res;
 }
 
-// 
+//
 //CHAPI: Now an pseudo-alias for ma_lookup_members_by_identifying(...)[0]
 function ma_lookup_member_id($ma_url, $signer, $member_id_key, $member_id_value)
 {
@@ -557,7 +557,7 @@ function ma_lookup_certificate($ma_url, $signer, $member_id)
                           'filter' => array('_GENI_MEMBER_SSL_CERTIFICATE',
                                             '_GENI_MEMBER_SSL_EXPIRATION'));
   $public_options = array_merge($public_options, $client->options());
-  $public_res = $client->lookup_public_member_info($client->creds(), 
+  $public_res = $client->lookup_public_member_info($client->creds(),
                                                    $public_options);
   if (! array_key_exists($member_urn, $public_res)) {
     error_log("No public member info available for $member_urn"
@@ -585,7 +585,7 @@ function ma_lookup_certificate($ma_url, $signer, $member_id)
   $private_options = array('match'=> array('MEMBER_UID'=>$member_id),
                            'filter'=>array('_GENI_MEMBER_SSL_PRIVATE_KEY'));
   $private_options = array_merge($private_options, $client->options());
-  $private_res = $client->lookup_private_member_info($client->creds(), 
+  $private_res = $client->lookup_private_member_info($client->creds(),
                                                      $private_options);
   if (array_key_exists($member_urn, $private_res)) {
     $private_key = $private_res[$member_urn]['_GENI_MEMBER_SSL_PRIVATE_KEY'];
@@ -678,7 +678,7 @@ function _lookup_public_members_details($client, $signer, $uid)
   $options = array('match'=>array('MEMBER_UID'=>$uid),
 		   'filter'=>$DETAILS_PUBLIC);
   $options = array_merge($options, $client->options());
-  $r = $client->lookup_public_member_info($client->creds(), 
+  $r = $client->lookup_public_member_info($client->creds(),
 					  $options);
   return $r;
 }
@@ -709,7 +709,7 @@ function _lookup_identifying_members_details($client, $signer, $uid)
   $options = array('match'=>array('MEMBER_UID'=>$uid),
 		   'filter'=>$DETAILS_IDENTIFYING);
   $options = array_merge($options, $client->options());
-  $r = $client->lookup_identifying_member_info($client->creds(), 
+  $r = $client->lookup_identifying_member_info($client->creds(),
 					       $options);
   return $r;
 }
@@ -719,7 +719,7 @@ function _lookup_public_identifying_members_details($client, $signer, $uids)
   global $DETAILS_IDENTIFYING;
   global $DETAILS_PUBLIC;
   $options = array('match'=> array('MEMBER_UID'=>$uids),
-		   'filter' => array_merge($DETAILS_IDENTIFYING, 
+		   'filter' => array_merge($DETAILS_IDENTIFYING,
 					   $DETAILS_PUBLIC));
   $options = array_merge($options, $client->options());
   $r = $client->lookup_public_identifying_member_info($client->creds(),
@@ -728,7 +728,7 @@ function _lookup_public_identifying_members_details($client, $signer, $uids)
 }
 
 
-// Lookup the display name for all member_ids in a given set of 
+// Lookup the display name for all member_ids in a given set of
 // rows, where the member_id is selected by given field name
 // Do not include the given signer in the query but add in the response
 // If there is no member other than the signer, don't make the query
@@ -738,7 +738,7 @@ function lookup_member_names_for_rows($ma_url, $signer, $rows, $field)
   $member_uuids = array();
   foreach($rows as $row) {
     $member_id = $row[$field];
-    if($member_id == $signer->account_id || in_array($member_id, $member_uuids)) 
+    if($member_id == $signer->account_id || in_array($member_id, $member_uuids))
       continue;
     $member_uuids[] = $member_id;
   }
@@ -753,8 +753,8 @@ function lookup_member_names_for_rows($ma_url, $signer, $rows, $field)
 }
 
 // Get the Portal's UUID from its cert, so we can avoid looking it up
-// This is important because the portal logs project join requests so loading 
-// a project page that has a join request causes this lookup, which fails on 
+// This is important because the portal logs project join requests so loading
+// a project page that has a join request causes this lookup, which fails on
 // an unknown UID like that of the portal.
 // Value is cached on the session to avoid doing the openssl computations very often.
 function get_portal_uid() {
@@ -936,7 +936,7 @@ function get_member_urn($ma_url, $signer, $id) {
     $options = array('match'=>array('MEMBER_UID'=>$id),
 		     'filter'=>array('MEMBER_URN'));
     $options = array_merge($options, $client->options());
-    $r = $client->lookup_public_member_info($client->creds(), 
+    $r = $client->lookup_public_member_info($client->creds(),
 					    $options);
 
     if (sizeof($r)>0) {

--- a/lib/php/tool-breadcrumbs.php
+++ b/lib/php/tool-breadcrumbs.php
@@ -113,7 +113,8 @@ $parents = array("profile.php" => "home.php",
 		 "tool-aggwarning.php" => "slice.php",
 		 "send_bug_report.php" => "slice.php",
 		 "contact-us.php" => "home.php",
-                 "updatekeys.php" => "slice.php");
+                 "updatekeys.php" => "slice.php",
+                 "transfer.php" => "profile.php");
 
 // Array from script name to a pretty name
 // FIXME: From a DB that the script uses too?
@@ -180,7 +181,8 @@ $names = array("home.php" => "Home",
 	       "tool-aggwarning.php" => "Query All Aggregates",
 	       "send_bug_report.php" => "Send Problem Report",
 	       "contact-us.php" => "Contact Us",
-               "updatekeys.php" => "Update SSH Keys");
+               "updatekeys.php" => "Update SSH Keys",
+               "transfer.php" => "Transfer Identity");
 
 // Look up in the 2 arrays above
 // Carefully checking for the project_id variant

--- a/lib/php/tools-user.php
+++ b/lib/php/tools-user.php
@@ -65,7 +65,7 @@ END;
     <li><a class='tab' data-tabindex=8 href='#preferences'>Preferences</a></li>
 	</ul>
 </div>
-		
+
 <?php
 
   // BEGIN the tabContent class
@@ -141,7 +141,7 @@ else
         $fingerprint_array = explode(' ', $result);
         $fingerprint = $fingerprint_array[1]; // store fingerprint
         unlink($fingerprint_key_filename);
-      
+
       $args['id'] = $key['id'];
       $query = http_build_query($args);
       if (is_null($key['private_key'])) {
@@ -458,7 +458,7 @@ $download_url = "https://" . $_SERVER['SERVER_NAME'] . "/secure/kmcert.php?close
 ?>
 
 <h2>Configure <code>omni</code></h2>
-<p><a href='http://trac.gpolab.bbn.com/gcf/wiki/Omni'><code>omni</code></a> is a command line tool intended for experienced users. 
+<p><a href='http://trac.gpolab.bbn.com/gcf/wiki/Omni'><code>omni</code></a> is a command line tool intended for experienced users.
 </p>
 
 <h3>Option 1: Automatic <code>omni</code> configuration</h3>
@@ -560,12 +560,12 @@ echo "</div>";
     });
   });
   function save_preferences(user_urn) {
-    params = { 
+    params = {
       user_urn: user_urn,
     <?php
       foreach($possible_prefs as $pref_name => $pref_values) {
         echo "$pref_name: $('#default_{$pref_name}').val(), \n";
-      }        
+      }
     ?>
     };
     $.post("do-update-user-preferences", params, function(data){
@@ -575,7 +575,7 @@ echo "</div>";
   }
 </script>
 
-<?php 
+<?php
 echo "<div class='card' id='preferences'>";
 echo "<h2>Portal preferences</h2>";
 

--- a/lib/php/tools-user.php
+++ b/lib/php/tools-user.php
@@ -404,6 +404,12 @@ if ($user->phone() != "")
 print "</table></div>\n";
 print "<p><button $disable_account_details onClick=\"window.location='modify.php'\">Modify user supplied account details </button> (e.g. to become a Project Lead).</p>";
 
+// FIXME: Change this to === 0 to present the button only for non-GPO logins
+if (preg_match('/@gpolab.bbn.com$/', $user->eppn) === 1) {
+  print "<p><button onClick=\"window.location='transfer.php'\">";
+  print "Transfer GENI Project Office account</button></p>";
+}
+
 $sfcred = $user->speaksForCred();
 if ($sfcred) {
   $sf_expires = $sfcred->expires();

--- a/lib/php/tools-user.php
+++ b/lib/php/tools-user.php
@@ -404,8 +404,8 @@ if ($user->phone() != "")
 print "</table></div>\n";
 print "<p><button $disable_account_details onClick=\"window.location='modify.php'\">Modify user supplied account details </button> (e.g. to become a Project Lead).</p>";
 
-// FIXME: Change this to === 0 to present the button only for non-GPO logins
-if (preg_match('/@gpolab.bbn.com$/', $user->eppn) === 1) {
+// Only present the transfer option for non-GPO logins
+if (preg_match('/@gpolab.bbn.com$/', $user->eppn) === 0) {
   print "<p><button onClick=\"window.location='transfer.php'\">";
   print "Transfer GENI Project Office account</button></p>";
 }

--- a/lib/php/util.php
+++ b/lib/php/util.php
@@ -204,9 +204,9 @@ function get_time_diff($exp_date) {
   return $num_hours;
 }
 
-// Return a red if $num_hours is small, an orange if medium, a green if large 
+// Return a red if $num_hours is small, an orange if medium, a green if large
 function get_urgency_color($num_hours) {
-  if ($num_hours < 24) { 
+  if ($num_hours < 24) {
     return "#EE583A";
   } else if ($num_hours < 48) {
     return "#FBC02D";
@@ -217,7 +217,7 @@ function get_urgency_color($num_hours) {
 
 // Return name of icons by same ideas as get_urgency_color
 function get_urgency_icon($num_hours) {
-  if ($num_hours < 24) { 
+  if ($num_hours < 24) {
     return "report";
   } else if ($num_hours < 48) {
     return "warning";
@@ -240,7 +240,7 @@ function already_in_list($candidates, $members, $true_if_any)
   $all_members = true;
   foreach($candidates as $candidate) {
     if (in_array($candidate, $members)) {
-	if ($true_if_any) 
+	if ($true_if_any)
 	  return true;
       } else {
       $all_emmbers = false;
@@ -322,4 +322,44 @@ function getBrowser() {
 	       'pattern'    => $pattern
 	       );
 }
+
+/**
+ * Verify a username/password at the GPO IdP.
+ *
+ * This is used to transfer accounts away from the GPO IdP.
+ */
+function verify_idp_user($gpo_user, $gpo_pass) {
+        global $idp_user;
+        global $idp_pass;
+        global $idp_host;
+
+        // These must be present in /etc/geni-ch/settings.php
+        if (! (isset($idp_user) && isset($idp_pass) && isset($idp_host))) {
+                error_log("IdP configuration missing from /etc/geni-ch/settings.php");
+                header('X-PHP-Response-Code: 400', true, 400);
+                return false;
+        }
+
+        $url = "https://$idp_host/manage/verifyuser.php?user=$gpo_user&pass=$gpo_pass";
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_pass");
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // enable this
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+
+        $output = curl_exec($ch);
+        if ($output === FALSE) {
+                $err = curl_error($ch);
+                error_log("curl_exec has failed. error: $err");
+                curl_close($ch);
+                header('X-PHP-Response-Code: 400', true, 400);
+                return false;
+        }
+
+        $info = curl_getinfo($ch);
+        curl_close($ch);
+        $response_code = $info["http_code"];
+        return $response_code;
+}
+
 ?>

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -193,11 +193,14 @@ dist_svcweb_DATA = \
 	www/portal/tool-omniconfig.php \
 	www/portal/tool-slices.js \
 	www/portal/tools-user.js \
+	www/portal/transfer.js \
+	www/portal/transfer.php \
 	www/portal/updatekeys.js \
 	www/portal/updatekeys.php \
 	www/portal/upload-file.php \
 	www/portal/upload-project-members.php \
 	www/portal/uploadsshkey.php \
+	www/portal/verifyuser.php \
 	www/portal/wimax-enable.php \
 	www/portal/wireless_operations.php \
 	www/portal/wireless_redirect.php

--- a/portal/Makefile.am
+++ b/portal/Makefile.am
@@ -96,6 +96,7 @@ dist_svcweb_DATA = \
 	www/portal/do-user-admin.php \
 	www/portal/do-user-search.php \
 	www/portal/dologout.php \
+	www/portal/dotransfer.php \
 	www/portal/downloadkeycert.php \
 	www/portal/downloadomnibundle.php \
 	www/portal/downloadputtykey.php \

--- a/portal/www/portal/dotransfer.php
+++ b/portal/www/portal/dotransfer.php
@@ -22,7 +22,7 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 require_once("user.php");
-require_once("header.php");
+include_once('/etc/geni-ch/settings.php');
 
 // Get the authenticated user for logging
 $user = geni_loadUser();
@@ -31,27 +31,33 @@ if (! isset($user)) {
         exit;
 }
 
-show_header('GENI Portal: Transfer Identity');
-include("tool-breadcrumbs.php");
-include("tool-showmessage.php");
-?>
-<script src="transfer.js"></script>
-<h1>Transfer Identity</h1>
-<p>
-This is where you will transfer your identity.
-</p>
+$KEY_USER = "user";
+$KEY_PASS = "pass";
 
-<label for="gpo_user">User:</label>
-<input type="text" name="gpo_user" id="gpo_user"><br/>
-<label for="gpo_pass">Password:</label>
-<input type="password" name="gpo_pass" id="gpo_pass"><br/>
-<button id="gpo_verify">Verify User</button>
+// Get these from the request
+$gpo_user = null;
+if (array_key_exists($KEY_USER, $_REQUEST)) {
+        $gpo_user = $_REQUEST[$KEY_USER];
+} else {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
 
-<div id="confirm_div" style="display:none;">
-  <p>Confirmation text and an execute button go here.</p>
-  <button id="confirm_transfer">Confirm</button>
-</div>
+$gpo_pass = null;
+if (array_key_exists($KEY_PASS, $_REQUEST)) {
+        $gpo_pass = $_REQUEST[$KEY_PASS];
+} else {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
 
-<?php
-include("footer.php");
+$response_code = verify_idp_user($gpo_user, $gpo_pass);
+if ($response_code != 200) {
+        error_log("Failed to verify user");
+        // Return whatever the IdP returned for status
+        header("X-PHP-Response-Code: $response_code", true, $response_code);
+}
+
+// We're good to transfer accounts - do that here
+
 ?>

--- a/portal/www/portal/dotransfer.php
+++ b/portal/www/portal/dotransfer.php
@@ -89,6 +89,8 @@ if ($result === null) {
 if ($result === TRUE) {
         error_log("swap succeeded");
         header('X-PHP-Response-Code: 200', true, 200);
+        $msg = "Your GENI Project Account has been transferred.";
+        $_SESSION['lastmessage'] = $msg;
 } else {
         error_log("clearinghouse could not swap " . print_r($result, true));
         header('X-PHP-Response-Code: 400', true, 400);

--- a/portal/www/portal/dotransfer.php
+++ b/portal/www/portal/dotransfer.php
@@ -60,34 +60,29 @@ if ($response_code != 200) {
 }
 
 // We're good to transfer accounts - do that here
-error_log("Starting to swap");
 $ma_url = get_first_service_of_type(SR_SERVICE_TYPE::MEMBER_AUTHORITY);
 $signer = Portal::getInstance();
 $source_eppn = "$gpo_user@gpolab.bbn.com";
 $source = ma_lookup_member_by_eppn($ma_url, $signer, $source_eppn);
 $source_urn = $source->{"urn"};
-error_log("source urn = $source_urn");
 $dest_urn = $user->urn();
-error_log("dest urn = $dest_urn");
 
 // We want the raw result, we don't want to redirect to the error page.
 $put_message_result_handler = 'no_redirect_result_handler';
 $result = ma_swap_identities($ma_url, $signer, $source_urn, $dest_urn);
 unset($put_message_result_handler);
-error_log("swap result = " . print_r($result, true));
 
 if ($result === null) {
         // This signals an error was received from the clearinghouse
         // Why, oh why, don't we propagate these things out of the
         // chapi client? Why?
-        error_log("swap result is null");
+        error_log("swap result is null, clearinghouse error");
         header('X-PHP-Response-Code: 400', true, 400);
         exit;
 }
 
 // At this point we've gotten a valid result, but was it success?
 if ($result === TRUE) {
-        error_log("swap succeeded");
         header('X-PHP-Response-Code: 200', true, 200);
         $msg = "Your GENI Project Account has been transferred.";
         $_SESSION['lastmessage'] = $msg;

--- a/portal/www/portal/dotransfer.php
+++ b/portal/www/portal/dotransfer.php
@@ -22,6 +22,7 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 require_once("user.php");
+include_once('ma_client.php');
 include_once('/etc/geni-ch/settings.php');
 
 // Get the authenticated user for logging
@@ -59,5 +60,37 @@ if ($response_code != 200) {
 }
 
 // We're good to transfer accounts - do that here
+error_log("Starting to swap");
+$ma_url = get_first_service_of_type(SR_SERVICE_TYPE::MEMBER_AUTHORITY);
+$signer = Portal::getInstance();
+$source_eppn = "$gpo_user@gpolab.bbn.com";
+$source = ma_lookup_member_by_eppn($ma_url, $signer, $source_eppn);
+$source_urn = $source->{"urn"};
+error_log("source urn = $source_urn");
+$dest_urn = $user->urn();
+error_log("dest urn = $dest_urn");
 
+// We want the raw result, we don't want to redirect to the error page.
+$put_message_result_handler = 'no_redirect_result_handler';
+$result = ma_swap_identities($ma_url, $signer, $source_urn, $dest_urn);
+unset($put_message_result_handler);
+error_log("swap result = " . print_r($result, true));
+
+if ($result === null) {
+        // This signals an error was received from the clearinghouse
+        // Why, oh why, don't we propagate these things out of the
+        // chapi client? Why?
+        error_log("swap result is null");
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+// At this point we've gotten a valid result, but was it success?
+if ($result === TRUE) {
+        error_log("swap succeeded");
+        header('X-PHP-Response-Code: 200', true, 200);
+} else {
+        error_log("clearinghouse could not swap " . print_r($result, true));
+        header('X-PHP-Response-Code: 400', true, 400);
+}
 ?>

--- a/portal/www/portal/dotransfer.php
+++ b/portal/www/portal/dotransfer.php
@@ -32,6 +32,14 @@ if (! isset($user)) {
         exit;
 }
 
+// Redirect GPO users to the home page. They are not eligible
+// for the transfer.
+if (preg_match('/@gpolab.bbn.com$/', $user->eppn) !== 0) {
+        error_log("dotransfer rejecting GPO user " . $user->eppn);
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
 $KEY_USER = "user";
 $KEY_PASS = "pass";
 

--- a/portal/www/portal/transfer.js
+++ b/portal/www/portal/transfer.js
@@ -1,0 +1,16 @@
+function transfer_verify() {
+  var user = $("#gpo_user").val();
+  var pass = $("#gpo_pass").val();
+  // alert("User " + user + " with pass " + pass);
+  var jqxhr = $.post("verifyuser.php", {user: user, pass: pass});
+  jqxhr.done(function(data, textStatus, jqXHR) {
+    alert("success");
+  })
+  jqxhr.fail(function(jqXHR, textStatus, errorThrown) {
+    alert("failure");
+  })
+}
+
+$(document).ready(function() {
+    $("#gpo_verify").click(transfer_verify);
+});

--- a/portal/www/portal/transfer.js
+++ b/portal/www/portal/transfer.js
@@ -20,7 +20,7 @@ function confirm_transfer() {
           var jqxhr = $.post("dotransfer.php", {user: user, pass: pass});
           jqxhr.done(function(data, textStatus, jqXHR) {
             alert("Transfer is complete.");
-            // Go to home screen?
+            window.location.href = "profile.php";
           })
           jqxhr.fail(function(jqXHR, textStatus, errorThrown) {
             alert("Transfer failed. Please send email to help@geni.net");

--- a/portal/www/portal/transfer.js
+++ b/portal/www/portal/transfer.js
@@ -4,11 +4,28 @@ function transfer_verify() {
   // alert("User " + user + " with pass " + pass);
   var jqxhr = $.post("verifyuser.php", {user: user, pass: pass});
   jqxhr.done(function(data, textStatus, jqXHR) {
-    alert("success");
+    confirm_transfer();
   })
   jqxhr.fail(function(jqXHR, textStatus, errorThrown) {
-    alert("failure");
+    alert("Incorrect username or password. Please try again.");
   })
+}
+
+function confirm_transfer() {
+  msg = "Are you sure you want to transfer your GPO account to this account?";
+  if (confirm(msg)) {
+          var user = $("#gpo_user").val();
+          var pass = $("#gpo_pass").val();
+          // alert("User " + user + " with pass " + pass);
+          var jqxhr = $.post("dotransfer.php", {user: user, pass: pass});
+          jqxhr.done(function(data, textStatus, jqXHR) {
+            alert("Transfer is complete.");
+            // Go to home screen?
+          })
+          jqxhr.fail(function(jqXHR, textStatus, errorThrown) {
+            alert("Transfer failed. Please send email to help@geni.net");
+          })
+  }
 }
 
 $(document).ready(function() {

--- a/portal/www/portal/transfer.php
+++ b/portal/www/portal/transfer.php
@@ -31,21 +31,49 @@ if (! isset($user)) {
         exit;
 }
 
+
+$sa_url = get_first_service_of_type(SR_SERVICE_TYPE::SLICE_AUTHORITY);
+$projects = get_projects_for_member($sa_url, $user, $user->account_id, true);
+
+
 show_header('GENI Portal: Transfer GPO Account');
 include("tool-breadcrumbs.php");
 include("tool-showmessage.php");
 ?>
 <script src="transfer.js"></script>
 <h1>Transfer GENI Project Office Account</h1>
+
+<?php
+if (count($projects) > 0) {
+  // -------------------------------------------------------------
+  // The user is in at least one project. They'll need to manually
+  // migrate their account.
+  // -------------------------------------------------------------
+?>
+<p>
+You cannnot transfer your GENI Project Office account to this account
+because this account is a member of
+<a href="dashboard.php#projects">at least one project</a>.
+If your GENI Project Office account is a member of any additional projects
+you will need to request to be added to those projects via the
+<a href="join-project.php">Join Project</a> page.
+</p>
+<p>
+If you need further assistance, please write to
+<a href="mailto:help@geni.net">help@geni.net</a>
+</p>
+<?php
+  exit;
+}
+
+// -------------------------------------------------------------------
+// Below here is executed if the user is NOT a member of any projects.
+// -------------------------------------------------------------------
+?>
 <p>
 In order to transfer the projects and slices from your GENI Project
 Office account to this account, please enter your GENI Project Office
 username and password below, then click on the "Transfer Account" button.
-</p>
-<p>
-<i>Note: you will no longer have access to any projects or slices on
-this account after the transfer.</i> If you have any questions, please
-write to <a href="mailto:help@geni.net">help@geni.net</a> for help.
 </p>
 
 <label for="gpo_user">User:</label>

--- a/portal/www/portal/transfer.php
+++ b/portal/www/portal/transfer.php
@@ -27,8 +27,14 @@ require_once("header.php");
 // Get the authenticated user for logging
 $user = geni_loadUser();
 if (! isset($user)) {
-        header('X-PHP-Response-Code: 400', true, 400);
-        exit;
+        relative_redirect('home.php');
+}
+
+// Redirect GPO users to the home page. They are not eligible
+// for the transfer.
+if (preg_match('/@gpolab.bbn.com$/', $user->eppn) !== 0) {
+        error_log("transfer rejecting GPO user " . $user->eppn);
+        relative_redirect('home.php');
 }
 
 

--- a/portal/www/portal/transfer.php
+++ b/portal/www/portal/transfer.php
@@ -31,21 +31,28 @@ if (! isset($user)) {
         exit;
 }
 
-show_header('GENI Portal: Transfer Identity');
+show_header('GENI Portal: Transfer GPO Account');
 include("tool-breadcrumbs.php");
 include("tool-showmessage.php");
 ?>
 <script src="transfer.js"></script>
-<h1>Transfer Identity</h1>
+<h1>Transfer GENI Project Office Account</h1>
 <p>
-This is where you will transfer your identity.
+In order to transfer the projects and slices from your GENI Project
+Office account to this account, please enter your GENI Project Office
+username and password below, then click on the "Transfer Account" button.
+</p>
+<p>
+<i>Note: you will no longer have access to any projects or slices on
+this account after the transfer.</i> If you have any questions, please
+write to <a href="mailto:help@geni.net">help@geni.net</a> for help.
 </p>
 
 <label for="gpo_user">User:</label>
 <input type="text" name="gpo_user" id="gpo_user"><br/>
 <label for="gpo_pass">Password:</label>
 <input type="password" name="gpo_pass" id="gpo_pass"><br/>
-<button id="gpo_verify">Verify User</button>
+<button id="gpo_verify">Transfer Account</button>
 
 <div id="confirm_div" style="display:none;">
   <p>Confirmation text and an execute button go here.</p>

--- a/portal/www/portal/transfer.php
+++ b/portal/www/portal/transfer.php
@@ -1,0 +1,52 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2017 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+require_once("user.php");
+require_once("header.php");
+
+// Get the authenticated user for logging
+$user = geni_loadUser();
+if (! isset($user)) {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+show_header('GENI Portal: Transfer Identity');
+include("tool-breadcrumbs.php");
+include("tool-showmessage.php");
+?>
+<script src="transfer.js"></script>
+<h1>Transfer Identity</h1>
+<p>
+This is where you will transfer your identity.
+</p>
+
+<label for="gpo_user">User:</label>
+<input type="text" name="gpo_user" id="gpo_user"><br/>
+<label for="gpo_pass">Password:</label>
+<input type="text" name="gpo_pass" id="gpo_pass"><br/>
+<button id="gpo_verify">Verify User</button>
+
+<?php
+include("footer.php");
+?>

--- a/portal/www/portal/verifyuser.php
+++ b/portal/www/portal/verifyuser.php
@@ -51,36 +51,10 @@ if (array_key_exists($KEY_PASS, $_REQUEST)) {
         exit;
 }
 
-
-// These must be present in /etc/geni-ch/settings.php
-if (! (isset($idp_user) && isset($idp_pass) && isset($idp_host))) {
-        error_log("IdP configuration missing from /etc/geni-ch/settings.php");
-        header('X-PHP-Response-Code: 400', true, 400);
-        exit;
-}
-
-$url = "https://$idp_host/manage/verifyuser.php?user=$gpo_user&pass=$gpo_pass";
-$ch = curl_init($url);
-curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_pass");
-curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // enable this
-curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
-curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-
-$output = curl_exec($ch);
-if ($output === FALSE) {
-        $err = curl_error($ch);
-        error_log("curl_exec has failed. error: $err");
-        curl_close($ch);
-        header('X-PHP-Response-Code: 400', true, 400);
-        exit;
-}
-
-$info = curl_getinfo($ch);
-$response_code = $info["http_code"];
+$response_code = verify_idp_user($gpo_user, $gpo_pass);
 if ($response_code != 200) {
         error_log("Failed to verify user");
 }
-curl_close($ch);
 
 // Return whatever the IdP returned for status
 header("X-PHP-Response-Code: $response_code", true, $response_code);

--- a/portal/www/portal/verifyuser.php
+++ b/portal/www/portal/verifyuser.php
@@ -1,0 +1,84 @@
+<?php
+//----------------------------------------------------------------------
+// Copyright (c) 2017 Raytheon BBN Technologies
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and/or hardware specification (the "Work") to
+// deal in the Work without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Work, and to permit persons to whom the Work
+// is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Work.
+//
+// THE WORK IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE WORK OR THE USE OR OTHER DEALINGS
+// IN THE WORK.
+//----------------------------------------------------------------------
+require_once("user.php");
+
+// Get the authenticated user for logging
+$user = geni_loadUser();
+if (! isset($user)) {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+$KEY_USER = "user";
+$KEY_PASS = "pass";
+
+// Get these from the request
+$gpo_user = null;
+if (array_key_exists($KEY_USER, $_REQUEST)) {
+        $gpo_user = $_REQUEST[$KEY_USER];
+} else {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+$gpo_pass = null;
+if (array_key_exists($KEY_PASS, $_REQUEST)) {
+        $gpo_pass = $_REQUEST[$KEY_PASS];
+} else {
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+
+// Get these from /etc settings
+$idp_user = "scott";
+$idp_password = "tiger";
+$idp_host = "idp.example.com";
+
+$url = "https://$idp_host/manage/verifyuser.php?user=$gpo_user&pass=$gpo_pass";
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_password");
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // enable this
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+
+$output = curl_exec($ch);
+if ($output === FALSE) {
+        $err = curl_error($ch);
+        error_log("curl_exec has failed. error: $err");
+        curl_close($ch);
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
+
+$info = curl_getinfo($ch);
+$response_code = $info["http_code"];
+if ($response_code != 200) {
+        error_log("Failed to verify user");
+}
+curl_close($ch);
+
+// Return whatever the IdP returned for status
+header("X-PHP-Response-Code: $response_code", true, $response_code);
+?>

--- a/portal/www/portal/verifyuser.php
+++ b/portal/www/portal/verifyuser.php
@@ -22,6 +22,7 @@
 // IN THE WORK.
 //----------------------------------------------------------------------
 require_once("user.php");
+include_once('/etc/geni-ch/settings.php');
 
 // Get the authenticated user for logging
 $user = geni_loadUser();
@@ -51,14 +52,16 @@ if (array_key_exists($KEY_PASS, $_REQUEST)) {
 }
 
 
-// Get these from /etc settings
-$idp_user = "scott";
-$idp_password = "tiger";
-$idp_host = "idp.example.com";
+// These must be present in /etc/geni-ch/settings.php
+if (! (isset($idp_user) && isset($idp_pass) && isset($idp_host))) {
+        error_log("IdP configuration missing from /etc/geni-ch/settings.php");
+        header('X-PHP-Response-Code: 400', true, 400);
+        exit;
+}
 
 $url = "https://$idp_host/manage/verifyuser.php?user=$gpo_user&pass=$gpo_pass";
 $ch = curl_init($url);
-curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_password");
+curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_pass");
 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // enable this
 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);


### PR DESCRIPTION
Provide a user interface for the account transfer clearinghouse API. Verify a user at the configured IdP, then perform the account transfer.

Accounts that are members of projects are ineligible for the transfer. The transfer is a swap of the internal ID, so the user would get disconnected from their projects. This is likely to be unexpected, so simply disallow it. It should be a rare case. These individuals can either migrate project membership manually (it's not hard) or remove themselves from their current projects and do the swap.

Closes #1786 
