### PR TITLE
Use configured from address in all portal emails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changes
 
+* Use configured from address in all portal emails
+  ([#1777](https://github.com/GENI-NSF/geni-portal/issues/1777))
 * Support migrating accounts from GPO IdP to NCSA IdP
   ([#1786](https://github.com/GENI-NSF/geni-portal/issues/1786))
 

--- a/kmtool/www/kmtool/kmsendemail.php
+++ b/kmtool/www/kmtool/kmsendemail.php
@@ -153,12 +153,14 @@ function get_user_conf_email_body($confirm_url) {
 // Note that we BCC portal admins
 function send_user_confirmation_email($user_email, $confirm_url) {
   global $portal_help_email;
+  global $portal_from_email;
   $subject = "GENI Account Email Confirmation";
   $body = get_user_conf_email_body($confirm_url);
-  $headers = "Reply-To: $portal_help_email";
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Reply-To: $portal_help_email";
   $headers .= "\r\nContent-Type: text/plain; charset=UTF-8";
   $headers .= "\r\nContent-Transfer-Encoding: 8bit";
-  return mail($user_email, $subject, $body, $headers);
+  return mail($user_email, $subject, $body, $headers, "-f $portal_from_email");
 }
 
 // Main body

--- a/lib/php/user.php
+++ b/lib/php/user.php
@@ -422,6 +422,8 @@ function send_attribute_fail_email()
 {
   // From /etc/geni-ch/settings.php
   global $portal_admin_email;
+  global $portal_from_email;
+  global $portal_help_email;
   $server_host = $_SERVER['SERVER_NAME'];
   $body = "An access attempt on $server_host failed";
   if (array_key_exists("Shib-Identity-Provider", $_SERVER)) {
@@ -435,10 +437,13 @@ function send_attribute_fail_email()
   foreach ($array as $var => $value) {
     $body .= "$var = $value\n";
   }
-  $headers = "Content-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit";
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>";
+  $headers .= "\r\nReply-To: $portal_help_email";
+  $headers .= "\r\nContent-Type: text/plain; charset=UTF-8";
+  $headers .= "\r\nContent-Transfer-Encoding: 8bit";
   mail($portal_admin_email,
           "Portal access failure on $server_host",
-       $body, $headers);
+       $body, $headers, "-f $portal_from_email");
 }
 
 function geni_load_user_by_eppn($eppn, $sfcred)

--- a/lib/php/user.php
+++ b/lib/php/user.php
@@ -111,7 +111,7 @@ class GeniUser
   }
 
   // If we haven't re-read the permissions in this many seconds, re-read
-  //  const STALE_PERMISSION_MANAGER_THRESHOLD_SEC = 30; 
+  //  const STALE_PERMISSION_MANAGER_THRESHOLD_SEC = 30;
 
   // MSB : Disable the permission manager cache: it is ALWAYS stale
   const STALE_PERMISSION_MANAGER_THRESHOLD_SEC = -1;
@@ -164,7 +164,7 @@ class GeniUser
       return null;
     }
   }
-  
+
   // Produce a pretty email name/address for sending like '"My Name" <my email>'
   function prettyEmailAddress() {
     return sprintf('"%s" <%s>', $this->prettyName(),
@@ -190,7 +190,7 @@ class GeniUser
     }
   }
 
-  // Is given permission (function/method/action) allowed in given 
+  // Is given permission (function/method/action) allowed in given
   // context_type/context_id for given user?
   function isAllowed($permission, $context_type, $context_id)
   {
@@ -215,10 +215,10 @@ class GeniUser
     //    error_log("PMT = " . $permission_manager_timestamp  . " " . $now);
 
     if (
-	($permission_manager == null) || 
+	($permission_manager == null) ||
 	($permission_manager_account_id != $this->account_id) ||
 	($now - $permission_manager_timestamp  > GeniUser::STALE_PERMISSION_MANAGER_THRESHOLD_SEC)
-	) 
+	)
       {
 	//	error_log("PM = " . $permission_manager . ", " . $this->account_id . ", " . $permission_manager_account_id);
 	//	error_log("PMT = " . $permission_manager_timestamp  . " " . $now);
@@ -228,8 +228,8 @@ class GeniUser
 	$permission_manager = get_permissions($cs_url, $this, $this->account_id);
 	$permission_manager_timestamp = $now;
 	$permission_manager_account_id = $this->account_id;
-	//	error_log("Refreshing permission manager " . $permission_manager_timestamp . " " 
-	//		  . $permission_manager_account_id . " " 
+	//	error_log("Refreshing permission manager " . $permission_manager_timestamp . " "
+	//		  . $permission_manager_account_id . " "
 	//		  . print_r($permission_manager, true));
 	$_SESSION[PERMISSION_MANAGER_TAG] = $permission_manager;
 	$_SESSION[PERMISSION_MANAGER_TIMESTAMP_TAG] = $now;
@@ -506,9 +506,9 @@ function geni_loadUser()
   $user = geni_load_user_by_eppn($eppn, $sfcred);
 
   // Non-operators can't use the portal while in maintenance: they go to the 'Maintenance" page
-  if ($in_maintenance_mode && 
-      !$user->isAllowed(CS_ACTION::ADMINISTER_MEMBERS, CS_CONTEXT_TYPE::MEMBER, 
-			null)) 
+  if ($in_maintenance_mode &&
+      !$user->isAllowed(CS_ACTION::ADMINISTER_MEMBERS, CS_CONTEXT_TYPE::MEMBER,
+			null))
     {
       error_log($user->prettyName() . " tried to access portal during maintenance");
       relative_redirect("maintenance_redirect_page.php");

--- a/portal/www/portal/do-handle-lead-request.php
+++ b/portal/www/portal/do-handle-lead-request.php
@@ -109,6 +109,8 @@ function handle_lead_request($request_id, $new_status, $approver, $user_uid, $re
 function send_approved_mail($new_lead, $reason, $approver)
 {
   global $portal_admin_email;
+  global $portal_help_email;
+  global $portal_from_email;
   $pretty_name = $new_lead->prettyName();
   $body = "$pretty_name approved to be project lead by $approver. \r\n";
   $body .= "Approved because: " . $reason . "\r\n";
@@ -116,11 +118,13 @@ function send_approved_mail($new_lead, $reason, $approver)
   $body .= "Their email: " . $new_lead->email() . "\r\n";
   $body .= "Their reason: " . $new_lead->reason() . "\r\n";
   $body .= "Their link: " . $new_lead->url() . "\r\n";
-  $headers = "Content-Type: text/plain; charset=UTF-8\r\n";
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Reply-To: $portal_help_email\r\n";
+  $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
   $headers .= "Content-Transfer-Encoding: 8bit\r\n";
   $to = $portal_admin_email;
   $subject = "Approved project lead request";
-  mail($to, $subject, $body, $headers);
+  mail($to, $subject, $body, $headers, "-f $portal_from_email");
 }
 
 ?>

--- a/portal/www/portal/do-handle-lead-request.php
+++ b/portal/www/portal/do-handle-lead-request.php
@@ -39,7 +39,7 @@ if (!$user->isAllowed(CS_ACTION::ADMINISTER_MEMBERS, CS_CONTEXT_TYPE::MEMBER, nu
   exit();
 }
 
-// Handle the HTTP request to figure out which LEAD request we're dealing with 
+// Handle the HTTP request to figure out which LEAD request we're dealing with
 if (array_key_exists('request_id', $_REQUEST) && array_key_exists('new_status', $_REQUEST) && array_key_exists('user_uid', $_REQUEST)) {
   $request_id = $_REQUEST['request_id'];
   $new_status = $_REQUEST['new_status'];
@@ -60,7 +60,7 @@ if (array_key_exists('request_id', $_REQUEST) && array_key_exists('new_status', 
 }
 
 // Update the lead_request db row identified by $request_id with $new_note
-function add_request_note($request_id, $new_note) 
+function add_request_note($request_id, $new_note)
 {
   $conn = portal_conn();
   $sql = "UPDATE lead_request set "
@@ -76,9 +76,9 @@ function add_request_note($request_id, $new_note)
   }
 }
 
-// Update the lead_request db row identified by $request_id with $new_status, 
+// Update the lead_request db row identified by $request_id with $new_status,
 // $approver, $user_uid, and $reason
-function handle_lead_request($request_id, $new_status, $approver, $user_uid, $reason, $signer) 
+function handle_lead_request($request_id, $new_status, $approver, $user_uid, $reason, $signer)
 {
   $ma_url = get_first_service_of_type(SR_SERVICE_TYPE::MEMBER_AUTHORITY);
   $conn = portal_conn();
@@ -106,7 +106,7 @@ function handle_lead_request($request_id, $new_status, $approver, $user_uid, $re
 }
 
 // Send email to admins about the fact that $new_lead was approved because of $reason
-function send_approved_mail($new_lead, $reason, $approver) 
+function send_approved_mail($new_lead, $reason, $approver)
 {
   global $portal_admin_email;
   $pretty_name = $new_lead->prettyName();

--- a/portal/www/portal/do-handle-project-request.php
+++ b/portal/www/portal/do-handle-project-request.php
@@ -225,8 +225,13 @@ $reason
   }
   $email_message = $email_message . "GENI Portal Operations";
 
-  $headers = "Cc: " . $user->prettyEmailAddress() . "\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit";
-  mail($email_address, $email_subject, $email_message,$headers);
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Cc: " . $user->prettyEmailAddress() . "\r\n";
+  $headers .= "Reply-To: $portal_help_email\r\n";
+  $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
+  $headers .= "Content-Transfer-Encoding: 8bit\r\n";
+  mail($email_address, $email_subject, $email_message, $headers,
+       "-f $portal_from_email");
 
 } // end of loop over rows to process
 

--- a/portal/www/portal/do-handle-project-request.php
+++ b/portal/www/portal/do-handle-project-request.php
@@ -34,7 +34,7 @@ require_once('sr_client.php');
 
 
 // Check the selections from the handle-project-request are valid
-// If so, add the approved members, resolve the requests and 
+// If so, add the approved members, resolve the requests and
 // send emails (positive or negative) to the requestors.
 
 
@@ -173,11 +173,11 @@ foreach($selections as $select_id => $attribs) {
   $resolution_status_label = "approved (see " . relative_url("project.php?project_id=".$project_id) . ")";
   $resolution_description = "";
   $email_subject = "Request to join GENI project $project_name";
-  //  $email_subject = "GENI Request " . print_r($request_id, true) . 
+  //  $email_subject = "GENI Request " . print_r($request_id, true) .
   //    " to join project " . $project_name;
   if ($role <= 0) {
     // This is a 'do not add' selection
-    // Send rejection letter 
+    // Send rejection letter
     // FIXME: Allow custom deny letter
     $num_members_rejected = $num_members_rejected + 1;
     $resolution_description = "Request rejected";
@@ -199,7 +199,7 @@ foreach($selections as $select_id => $attribs) {
       }
     }
     // This is an 'add' selection
-    // Add member 
+    // Add member
     add_project_member($sa_url, $user, $project_id, $member_id, $role);
     // I _believe_ we'll have been redirected to the error page if the add fails
 
@@ -215,7 +215,7 @@ foreach($selections as $select_id => $attribs) {
 
   // Send acceptance/rejection letter
   $hostname = $_SERVER['SERVER_NAME'];
-  $email_message  = "Your request to join GENI project " . $project_name . 
+  $email_message  = "Your request to join GENI project " . $project_name .
     " has been " . $resolution_status_label . " by " . $user->prettyName() . ".\n\n";
   if (isset($reason) && $reason != '') {
     $email_message = $email_message . "
@@ -230,9 +230,8 @@ $reason
 
 } // end of loop over rows to process
 
-$_SESSION['lastmessage'] = "Added $num_members_added members; Rejected $num_members_rejected members"; 
+$_SESSION['lastmessage'] = "Added $num_members_added members; Rejected $num_members_rejected members";
 
-relative_redirect("project.php?project_id=".$project_id); 
+relative_redirect("project.php?project_id=".$project_id);
 
 ?>
-

--- a/portal/www/portal/do-modify.php
+++ b/portal/www/portal/do-modify.php
@@ -170,7 +170,12 @@ if (isset($log_msg)) {
     $body .= "(Duplicate request)";
   }
 
-  mail($portal_admin_email, $subject, $body);
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Reply-To: $portal_help_email\r\n";
+  $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
+  $headers .= "Content-Transfer-Encoding: 8bit\r\n";
+
+  mail($portal_admin_email, $subject, $body, $headers, "-f $portal_from_email");
 }
 
 // Now email them to say we got their lead request (if this is a new request)
@@ -190,14 +195,15 @@ if (! $duplicateRequest and $pi_request and ! $is_pi) {
   $body .= "GENI Experimenter Support\n";
   $body .= "help@geni.net\n";
 
-  $headers = "Reply-To: help@geni.net\r\n";
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Reply-To: $portal_help_email\r\n";
   $headers .= "Bcc: $portal_admin_email\r\n";
   $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
   $headers .= "Content-Transfer-Encoding: 8bit\r\n";
 
   $to = $user->prettyEmailAddress();
   $subject = "Your GENI Project Lead request has been received";
-  mail($to, $subject, $body, $headers);
+  mail($to, $subject, $body, $headers, "-f $portal_from_email");
 }
 
 /*
@@ -237,7 +243,13 @@ if (! empty($change_text)) {
   if ($req_name !== $user->prettyName()) {
     $subject = "GENI name change posted";
   }
-  mail($portal_admin_email, $subject, $body);
+
+  $headers = "From: \"The GENI Portal\" <$portal_from_email>\r\n";
+  $headers .= "Reply-To: $portal_help_email\r\n";
+  $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
+  $headers .= "Content-Transfer-Encoding: 8bit\r\n";
+
+  mail($portal_admin_email, $subject, $body, $headers, "-f $portal_from_email");
 }
 
 /*

--- a/portal/www/portal/join-this-project.php
+++ b/portal/www/portal/join-this-project.php
@@ -186,7 +186,7 @@ Thank you,\n" . $user->prettyName() . "\n";
 
   mail($lead->prettyEmailAddress(),
        "Request to Join GENI project $project_name",
-       $message, $headers);
+       $message, $headers, "-f $portal_from_email");
 
   // We could supply the -f arg to make bounces go back to this portal user,
   // but we probably want to know if the lead's email address is bouncing.

--- a/portal/www/portal/send_bug_report.php
+++ b/portal/www/portal/send_bug_report.php
@@ -283,7 +283,8 @@ Content-Disposition: attachment
     $message .= "\r\n";
     $message .= "--PHP-mixed-$boundary_string--\r\n";
 
-    $retVal = mail($to, $subject, $message, implode("\r\n", $headers));
+    $retVal = mail($to, $subject, $message, implode("\r\n", $headers),
+                   "-f $portal_from_email");
 
     if($retVal) {
         if($cc) {


### PR DESCRIPTION
Always use `$portal_from_address` in the `From:` header in email. `$portal_from_address` is set in the config file.

Fixes #1777 