### PR TITLE
Encode arguments when verifying a user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Encode arguments when verifying a user
+  ([#1794](https://github.com/GENI-NSF/geni-portal/issues/1794))
 
 ## Installation Notes
 

--- a/lib/php/util.php
+++ b/lib/php/util.php
@@ -340,12 +340,16 @@ function verify_idp_user($gpo_user, $gpo_pass) {
                 return false;
         }
 
-        $url = "https://$idp_host/manage/verifyuser.php?user=$gpo_user&pass=$gpo_pass";
+        $url = "https://$idp_host/manage/verifyuser.php";
+        $args = array('user' => $gpo_user, 'pass' => $gpo_pass);
+        $data = http_build_query($args);
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_USERPWD, "$idp_user:$idp_pass");
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE); // enable this
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, FALSE);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
 
         $output = curl_exec($ch);
         if ($output === FALSE) {


### PR DESCRIPTION
Also use POST instead of GET when verifying a user.

Fixes #1794 
