### PR TITLE
Change spelling of EXPIRED

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-* None
+* Change spelling of EXPIRED
+  ([#1809](https://github.com/GENI-NSF/geni-portal/issues/1809))
 
 ## Installation Notes
 

--- a/lib/php/pa_client.php
+++ b/lib/php/pa_client.php
@@ -397,7 +397,7 @@ function get_project_info_for_member($sa_url, $signer, $member_id,
 
   $result = array();
   foreach($rows as $row) {
-    $expired = $row['EXPIRED'];
+    $expired = $row['PROJECT_EXPIRED'];
     if ($expired && (!$include_expired)) continue;
     //    error_log("ROW = " . print_r($row, true));
     $new_row = project_details_chapi2portal($row);
@@ -436,7 +436,7 @@ function get_projects_for_member($sa_url, $signer, $member_id, $is_member)
   // if not a member
   $current = array();
   foreach ($rows as $row) {
-    if ($row['EXPIRED'] == false) {
+    if ($row['PROJECT_EXPIRED'] == false) {
       $current[] = $row;
     }
   }

--- a/lib/php/pa_client.php
+++ b/lib/php/pa_client.php
@@ -32,7 +32,7 @@
 //   get_project_members(sa_url, project_id, role=null) // null => Any
 //   get_projects_for_member(sa_url, signer, member_id, is_member)
 //   lookup_project_details(sa_url, project_uuids)
-//   modify_project_membership(sa_url, signer, project_id, 
+//   modify_project_membership(sa_url, signer, project_id,
 //			 members_to_add, members_to_change_role, members_to_remove)
 //   add_project_member(sa_url, project_id, member_id, role)
 //   remove_project_member(sa_url, project_id, member_id)
@@ -55,7 +55,7 @@ if(!isset($project_cache)) {
   $project_cache = array();
 }
 
-// Create a project with given name, lead_id (UUID of lead member), email to contact on all 
+// Create a project with given name, lead_id (UUID of lead member), email to contact on all
 // matters related to project, and documentation purpose of project
 function create_project($sa_url, $signer, $project_name, $lead_id, $project_purpose, $expiration)
 {
@@ -116,7 +116,7 @@ $PACHAPI2PORTAL = array('PROJECT_UID'=>PA_PROJECT_TABLE_FIELDNAME::PROJECT_ID,
 			'PROJECT_EXPIRATION'=>PA_PROJECT_TABLE_FIELDNAME::EXPIRATION,
 			'PROJECT_EXPIRED'=>PA_PROJECT_TABLE_FIELDNAME::EXPIRED);
 
-$PAMEMBERCHAPI2PORTAL = array('PROJECT_ROLE' => PA_PROJECT_MEMBER_TABLE_FIELDNAME::ROLE, 
+$PAMEMBERCHAPI2PORTAL = array('PROJECT_ROLE' => PA_PROJECT_MEMBER_TABLE_FIELDNAME::ROLE,
 			      'PROJECT_MEMBER_UID' => PA_PROJECT_MEMBER_TABLE_FIELDNAME::MEMBER_ID);
 
 $PADETAILSKEYS = array('PROJECT_UID',
@@ -193,10 +193,10 @@ function lookup_project($sa_url, $signer, $project_id)
     return null;
   }
 
-  // FIXME: Could be >1? 
+  // FIXME: Could be >1?
   $details = $details[0];  // just take the first match
   $project_cache[$project_id] = $details;
-  
+
   return $details;
 }
 
@@ -225,9 +225,9 @@ function lookup_project_by_name($sa_url, $signer, $project_name)
     return null;
   }
 
-  // FIXME: Could be >1? 
+  // FIXME: Could be >1?
   $details = $details[0];  // just take the first match
-  
+
   return $details;
 }
 
@@ -283,9 +283,9 @@ function _conv_mid2urn_map($sa_url, $signer, $amap)
 // $members_to_add and $members_to_change role are both
 //     dictionaries of {member_id => role, ....}
 // $members_to_delete is a list of member_ids
-function modify_project_membership($sa_url, $signer, $project_id, 
-				   $members_to_add, 
-				   $members_to_change, 
+function modify_project_membership($sa_url, $signer, $project_id,
+				   $members_to_add,
+				   $members_to_change,
 				   $members_to_remove)
 {
   $project_urn = get_project_urn($sa_url, $signer, $project_id);
@@ -294,7 +294,7 @@ function modify_project_membership($sa_url, $signer, $project_id,
   $members_to_add_new = _conv_mid2urn_map($sa_url, $signer, $members_to_add);
   $members_to_change_new = _conv_mid2urn_map($sa_url, $signer, $members_to_change);
   $members_to_remove_new = _conv_mid2urn($sa_url, $signer, $members_to_remove);
-  
+
   $options = array();
   if (sizeof($members_to_add_new)>0)    { $options['members_to_add']    = $members_to_add_new; }
   if (sizeof($members_to_change_new)>0) { $options['members_to_change'] = $members_to_change_new; }
@@ -314,7 +314,7 @@ function modify_project_membership($sa_url, $signer, $project_id,
 // Assumes lead is already a member
 function change_lead($sa_url, $signer, $project_id, $prev_lead_id, $new_lead_id)
 {
-  $members_to_change = array($prev_lead_id => CS_ATTRIBUTE_TYPE::ADMIN, 
+  $members_to_change = array($prev_lead_id => CS_ATTRIBUTE_TYPE::ADMIN,
 			     $new_lead_id => CS_ATTRIBUTE_TYPE::LEAD);
   $result = modify_project_membership($sa_url, $signer, $project_id,
 				      array(), $members_to_change, array());
@@ -325,7 +325,7 @@ function change_lead($sa_url, $signer, $project_id, $prev_lead_id, $new_lead_id)
 function add_project_member($sa_url, $signer, $project_id, $member_id, $role)
 {
   $member_roles = array($member_id => $role);
-  $result = modify_project_membership($sa_url, $signer, $project_id, 
+  $result = modify_project_membership($sa_url, $signer, $project_id,
 				    $member_roles, array(), array());
   return $result;
 }
@@ -334,7 +334,7 @@ function add_project_member($sa_url, $signer, $project_id, $member_id, $role)
 function remove_project_member($sa_url, $signer, $project_id, $member_id)
 {
   $member_to_remove = array($member_id);
-  $result = modify_project_membership($sa_url, $signer, $project_id, 
+  $result = modify_project_membership($sa_url, $signer, $project_id,
 				    array(), array(), $member_to_remove);
   return $result;
 }
@@ -343,15 +343,15 @@ function remove_project_member($sa_url, $signer, $project_id, $member_id)
 function change_member_role($sa_url, $signer, $project_id, $member_id, $role)
 {
   $member_roles = array($member_id => $role);
-  $result = modify_project_membership($sa_url, $signer, $project_id, 
+  $result = modify_project_membership($sa_url, $signer, $project_id,
 				    array(), $member_roles, array());
   return $result;
 }
 
 // Return list of member ID's and roles associated with given project
 // If role is provided, filter to members of given role
-function get_project_members($sa_url, $signer, $project_id, 
-			     $role=null, $project_urn = null) 
+function get_project_members($sa_url, $signer, $project_id,
+			     $role=null, $project_urn = null)
 {
   if(is_null($project_urn))
     $project_urn = get_project_urn($sa_url, $signer, $project_id);
@@ -365,12 +365,12 @@ function get_project_members($sa_url, $signer, $project_id,
   $result = $client->lookup_project_members($project_urn, $client->creds(), $options);
   //  error_log("GPM.result = " . print_r($result, true));
   $converted_result = array();
-  foreach($result as $row) { 
+  foreach($result as $row) {
     $converted_row = project_member_chapi2portal($row);
     $converted_row = convert_role($converted_row);
     $converted_result[] = $converted_row;
   }
-  return $converted_result;  
+  return $converted_result;
 
 }
 
@@ -379,7 +379,7 @@ function get_project_members($sa_url, $signer, $project_id,
 // PROJECT_UID
 // PROJECT_ROLE
 // Optionally, include expired projects
-function get_project_info_for_member($sa_url, $signer, $member_id, 
+function get_project_info_for_member($sa_url, $signer, $member_id,
 				     $include_expired=false)
 {
   if (! is_object($signer)) {
@@ -428,12 +428,12 @@ function get_projects_for_member($sa_url, $signer, $member_id, $is_member)
   $member_urn = get_member_urn(sa_to_ma_url($sa_url), $signer, $member_id);
   $rows = $client->lookup_projects_for_member($member_urn, $client->creds(),
                                               $client->options());
-  if ($is_member) {    
+  if ($is_member) {
     $project_uuids = array_map(function ($row) { return $row['PROJECT_UID']; },
                                array_values($rows));
     return $project_uuids;
   }
-  // if not a member 
+  // if not a member
   $current = array();
   foreach ($rows as $row) {
     if ($row['EXPIRED'] == false) {
@@ -461,13 +461,13 @@ function lookup_project_details($sa_url, $signer, $project_uuids)
   //  $get_projects_message['operation'] = 'lookup_project_details';
   //  $get_projects_message[PA_ARGUMENT::PROJECT_UUIDS] = $project_uuids;
   //  $results = put_message($sa_url, $get_projects_message,
-  //			 $cert, $key, 
+  //			 $cert, $key,
   //			 $signer->certificate(), $signer->privateKey());
-  //			 
+  //
   //  $results2 = array();
   //  foreach ($results as $project) {
   //  	  $results2[ $project['project_id'] ] = $project;
-  //  }			 
+  //  }
   //  return $results2;
 
   //  error_log("PIDS = " . print_r($project_uuids, true));
@@ -502,13 +502,13 @@ function lookup_project_details($sa_url, $signer, $project_uuids)
 function invite_member($sa_url, $signer, $project_id, $role)
 {
   $client = XMLRPCClient::get_client($sa_url, $signer);
-  $result = $client->invite_member($role, $project_id, 
+  $result = $client->invite_member($role, $project_id,
 				   $client->creds(), $client->options());
   return $result;
   //  $invite_member_message['operation'] = 'invite_member';
   //  $invite_member_message[PA_ARGUMENT::PROJECT_ID] = $project_id;
   //  $invite_member_message[PA_ARGUMENT::ROLE_TYPE] = $role;
-  //  $result = put_message($sa_url, $invite_member_message, 
+  //  $result = put_message($sa_url, $invite_member_message,
   //		       $signer->certificate(), $signer->privateKey());
   //  return $result;
 }
@@ -527,7 +527,7 @@ function accept_invitation($sa_url, $signer, $invitation_id)
   //  $accept_invitation_message['operation'] = 'accept_invitation';
   //  $accept_invitation_message[PA_ARGUMENT::INVITATION_ID] = $invitation_id;
   //  $accept_invitation_message[PA_ARGUMENT::MEMBER_ID] = $user->account_id;
-  //  $result = put_message($sa_url, $accept_invitation_message, 
+  //  $result = put_message($sa_url, $accept_invitation_message,
   //			$signer->certificate(), $signer->privateKey());
   //   return $result;
 }
@@ -541,13 +541,13 @@ function lookup_project_attributes($sa_url, $signer, $project_id)
   //  error_log("OPTIONS: " . print_r($options,true));
   $options = array_merge($options, $client->options());
   $res = $client->lookup_project_attributes($project_urn, $client->creds(), $options);
-  //  error_log("RES: " . print_r($res,true)); 
+  //  error_log("RES: " . print_r($res,true));
   return $res;
 
   /*  global $user;
   $lookup_project_attributes_message['operation'] = 'lookup_project_attributes';
   $lookup_project_attributes_message[PA_ARGUMENT::PROJECT_ID] = $project_id;
-  $results = put_message($sa_url, $lookup_project_attributes_message, 
+  $results = put_message($sa_url, $lookup_project_attributes_message,
 			 $signer->certificate(), $signer->privateKey());
   return $results;
   */
@@ -564,15 +564,15 @@ function add_project_attribute($sa_url, $signer, $project_id, $name, $value)
   $result = $client->add_project_attribute($project_urn, $client->creds(), $options);
   //  error_log("APA.result = " . print_r($result, true));
   return $result;
-    
-  //   global $user; 
-  //   $add_project_attribute_message['operation'] = 'add_project_attribute'; 
-  //   $add_project_attribute_message[PA_ARGUMENT::PROJECT_ID] = $project_id; 
-  //   $add_project_attribute_message[PA_ATTRIBUTE::NAME] = $name; 
-  //   $add_project_attribute_message[PA_ATTRIBUTE::VALUE] = $value; 
-  //   $results = put_message($sa_url, $add_project_attribute_message,  
-  // 			 $signer->certificate(), $signer->privateKey()); 
-  //   return $results; 
+
+  //   global $user;
+  //   $add_project_attribute_message['operation'] = 'add_project_attribute';
+  //   $add_project_attribute_message[PA_ARGUMENT::PROJECT_ID] = $project_id;
+  //   $add_project_attribute_message[PA_ATTRIBUTE::NAME] = $name;
+  //   $add_project_attribute_message[PA_ATTRIBUTE::VALUE] = $value;
+  //   $results = put_message($sa_url, $add_project_attribute_message,
+  // 			 $signer->certificate(), $signer->privateKey());
+  //   return $results;
 }
 
 // Remove attribute (name) from a given project
@@ -591,7 +591,7 @@ function remove_project_attribute($sa_url, $signer, $project_id, $name)
   //  $remove_project_attribute_message['operation'] = 'remove_project_attribute';
   //  $remove_project_attribute_message[PA_ARGUMENT::PROJECT_ID] = $project_id;
   //  $remove_project_attribute_message[PA_ATTRIBUTE::NAME] = $name;
-  //  $results = put_message($sa_url, $remove_project_attribute_message, 
+  //  $results = put_message($sa_url, $remove_project_attribute_message,
   //			 $signer->certificate(), $signer->privateKey());
   //  return $results;
 }

--- a/lib/php/sa_client.php
+++ b/lib/php/sa_client.php
@@ -519,8 +519,8 @@ function get_slices_for_member($sa_url, $signer, $member_id, $is_member, $role=n
   $converted_results = array();
   foreach($results as $row) {
     $converted_row = array(SA_SLICE_MEMBER_TABLE_FIELDNAME::SLICE_ID => $row['SLICE_UID'],
-			   SA_SLICE_MEMBER_TABLE_FIELDNAME::ROLE => $row['SLICE_ROLE'],
-			   SA_SLICE_TABLE_FIELDNAME::EXPIRED => $row['EXPIRED']);
+                           SA_SLICE_MEMBER_TABLE_FIELDNAME::ROLE => $row['SLICE_ROLE'],
+                           SA_SLICE_TABLE_FIELDNAME::EXPIRED => $row['SLICE_EXPIRED']);
     $converted_row = convert_role($converted_row);
     $converted_results[] = $converted_row;
   }


### PR DESCRIPTION
The clearinghouse fixed a bug with the spelling of EXPIRED. Use
the new keywords to be compatible with the latest clearinghouse code.

Fixes #1809
See also GENI-NSF/geni-ch#537
