### PR TITLE
Update kmhome.php

### DIFF
--- a/kmtool/www/kmtool/kmhome.php
+++ b/kmtool/www/kmtool/kmhome.php
@@ -36,7 +36,7 @@ $member = null;
 $member_id = null;
 $authorized_tools_for_user = array();
 if (array_key_exists($member_id_key, $_SERVER)) {
-  $member_id_value = $_SERVER[$member_id_key];
+  $member_id_value = strtolower($_SERVER[$member_id_key]);
   $members = ma_lookup_member_id($ma_url, $km_signer, 
 				 $member_id_key, $member_id_value);
 } else if (array_key_exists("member_id", $_REQUEST)) {


### PR DESCRIPTION
Upon investigation and looking at the GENI POrtal code , it seems this line https://github.com/GENI-NSF/geni-portal/blob/7be94e8564b7b6e5dfe88a0d67eaf6eead5ed62f/kmtool/www/kmtool/kmhome.php#L39 is to blame. A user's EPPN is used as key to find the user's accounts details from the GENI CH. All EPPNS in the GENI CH are saved in lowercase. It is possible that somewhere in the geni CH and GENI Portal code, EPPNS are converted to lowercase and saved.

Campuses usually have eppns as lower case strings which is why this bug never triggered until this one user whose EPPN returned from his campus is in uppercase. He was unable to activate his account because the member details were not matching up with the uppercase EPPN.