### PR TITLE
Update sa_client.php

### DIFF
--- a/lib/php/sa_client.php
+++ b/lib/php/sa_client.php
@@ -505,8 +505,13 @@ function get_slices_for_member($sa_url, $signer, $member_id, $is_member, $role=n
   if ($is_member) {
     $options = array();
     if (!is_null($role)) {
-      $options = array('match'=>array('SLICE_ROLE'=>$role));
+      $options = array('match'=>array('SLICE_ROLE'=>$role,'SLICE_EXPIRED'=>'f'));
     }
+    else
+    {
+      $options = array('match'=>array('SLICE_EXPIRED'=>'f'));
+    }
+
     $options = array_merge($options, $client->options());
     $results = $client->lookup_slices_for_member($member_urn, $client->creds(), $options);
   } else {


### PR DESCRIPTION
lookup slices for member that are not expired only. Underlying XMLRPC calls fail in PHP due to large datasets to be decoded.